### PR TITLE
Fix poison blackbox

### DIFF
--- a/src/main/scala/dsptools/Driver.scala
+++ b/src/main/scala/dsptools/Driver.scala
@@ -54,7 +54,7 @@ object Driver {
 }
 
 class ReplOptionsManager
-  extends ExecutionOptionsManager("chisel-testers")
+  extends ExecutionOptionsManager("dsptools-repl")
     with HasInterpreterOptions
     with HasChiselExecutionOptions
     with HasFirrtlOptions

--- a/src/main/scala/dsptools/numbers/DspRealBlackBox.scala
+++ b/src/main/scala/dsptools/numbers/DspRealBlackBox.scala
@@ -29,7 +29,7 @@ abstract class DspRealTwoArgumentToDouble extends BlackBoxImplementation {
     val doubleArg2 = bigIntBitsToDouble(arg2.value)
     val doubleResult = twoOp(doubleArg1, doubleArg2)
     val result = doubleToBigIntBits(doubleResult)
-    ConcreteSInt(result, DspReal.UnderlyingWidth).asUInt
+    ConcreteSInt(result, DspReal.UnderlyingWidth, arg1.poisoned || arg2.poisoned).asUInt
 
 //    TypeInstanceFactory(tpe, result)
   }
@@ -56,7 +56,7 @@ abstract class DspRealOneArgumentToDouble extends BlackBoxImplementation {
     val doubleArg1 = bigIntBitsToDouble(arg1.value)
     val doubleResult = oneOp(doubleArg1)
     val result = doubleToBigIntBits(doubleResult)
-    ConcreteSInt(result, DspReal.UnderlyingWidth).asUInt
+    ConcreteSInt(result, DspReal.UnderlyingWidth, arg1.poisoned).asUInt
   }
 }
 
@@ -83,7 +83,7 @@ abstract class DspRealTwoArgumentToBoolean extends BlackBoxImplementation {
     val doubleArg2 = bigIntBitsToDouble(arg2.value)
     val booleanResult = twoOp(doubleArg1, doubleArg2)
     val result = if(booleanResult) Big1 else Big0
-    TypeInstanceFactory(tpe, result)
+    TypeInstanceFactory(tpe, result, arg1.poisoned || arg2.poisoned)
   }
 }
 

--- a/src/test/scala/examples/RealAdderSpec.scala
+++ b/src/test/scala/examples/RealAdderSpec.scala
@@ -4,7 +4,7 @@ package examples
 
 import chisel3.core._
 import chisel3.iotesters.{Backend, PeekPokeTester}
-import dsptools.DspTester
+import dsptools.{ReplOptionsManager, DspTester}
 import dsptools.numbers.DspReal
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -20,6 +20,15 @@ class RealAdder extends Module {
   register1 := io.a1 + io.a2
 
   io.c := register1
+}
+
+object RealAdder {
+  def main(args: Array[String]) {
+    val optionsManager = new ReplOptionsManager
+    if(optionsManager.parse(args)) {
+      dsptools.Driver.executeFirrtlRepl(() => new RealAdder, optionsManager)
+    }
+  }
 }
 
 class RealAdderTester(c: RealAdder) extends DspTester(c) {


### PR DESCRIPTION
fixes poison values not making it through black boxes
adds example of calling firrtl-repl from RealAdder
FixName in dsp options manager