### PR TITLE
Work to make the IsReal family work for FixedPoint

### DIFF
--- a/src/main/scala/dsptools/numbers/FixedPointRing.scala
+++ b/src/main/scala/dsptools/numbers/FixedPointRing.scala
@@ -44,11 +44,23 @@ trait FixedPointSigned extends Any with Signed[FixedPoint] with hasContext {
   def abs(a: FixedPoint): FixedPoint = Mux(a > FixedPoint.fromBigInt(0), a, FixedPoint.fromBigInt(0)-a)
 }
 trait FixedPointIsReal extends Any with IsReal[FixedPoint] with FixedPointOrder with FixedPointSigned with hasContext {
-  def toDouble(a: FixedPoint): DspReal = ???
-  def ceil(a: FixedPoint): FixedPoint = ???
-  def floor(a: FixedPoint): FixedPoint = ???
-  def isWhole(a: FixedPoint): Bool = ???
-  def round(a: FixedPoint): FixedPoint = ???
+  /**
+    * Todo: I don't think this can be done without a parameterized black box
+    * It will need to know the binary point and bits in order to
+    * @param a the fixed point number to convert
+    * @return
+    */
+  //TODO: commented out for now in IsReal also, see comment there
+//  def toDouble(a: FixedPoint): DspReal = ???
+
+  def ceil(a: FixedPoint): FixedPoint = {
+    Mux(a === floor(a), floor(a), floor(a) + 1.F(0))
+  }
+  def floor(a: FixedPoint): FixedPoint = a.setBinaryPoint(0)
+  def isWhole(a: FixedPoint): Bool = a === floor(a)
+  def round(a: FixedPoint): FixedPoint = {
+    (a + 0.5.F(1)).setBinaryPoint(0)
+  }
 }
 
 trait ConvertableToFixedPoint extends ConvertableTo[FixedPoint] with hasContext {

--- a/src/main/scala/dsptools/numbers/IsReal.scala
+++ b/src/main/scala/dsptools/numbers/IsReal.scala
@@ -37,8 +37,11 @@ trait IsReal[A<:Data] extends Any with Order[A] with Signed[A] {
 
   /**
     * Approximates `a` as a `Double`.
+    * This is problematic conversion from FixedPoint
+    * to DspReal, where inference can make computing this
+    * difficult
     */
-  def toDouble(a: A): DspReal
+//  def toDouble(a: A): DspReal
 }
 
 object IsReal {

--- a/src/main/scala/dsptools/numbers/Ops.scala
+++ b/src/main/scala/dsptools/numbers/Ops.scala
@@ -78,7 +78,7 @@ final class SignedOps[A:Signed](lhs: A) {
 }
 
 final class IsRealOps[A<:Data](lhs:A)(implicit ev:IsReal[A]) {
-  def isWhole(): Boolean = macro Ops.unop[Boolean]
+  def isWhole(): Bool = macro Ops.unop[Bool]
   def ceil(): A = macro Ops.unop[A]
   def floor(): A = macro Ops.unop[A]
   def round(): A = macro Ops.unop[A]

--- a/src/test/scala/dsptools/numbers/FixedPointSpec.scala
+++ b/src/test/scala/dsptools/numbers/FixedPointSpec.scala
@@ -1,0 +1,51 @@
+// See LICENSE for license details.
+
+package dsptools.numbers
+
+import chisel3._
+import dsptools.DspTester
+import org.scalatest.{FreeSpec, Matchers}
+import dsptools.numbers.implicits._
+
+class FixedRing1(val width: Int, val binaryPoint: Int) extends Module {
+  val io = IO(new Bundle {
+    val in = Input(FixedPoint(width = width, binaryPoint = binaryPoint))
+    val floor = Output(FixedPoint(width = width, binaryPoint = binaryPoint))
+    val ceil = Output(FixedPoint(width = width, binaryPoint = binaryPoint))
+    val isWhole = Output(Bool())
+    val round = Output(FixedPoint(width = width, binaryPoint = binaryPoint))
+    val real = Output(DspReal(1.0))
+  })
+
+  io.floor := io.in.floor()
+  io.ceil := io.in.ceil()
+  io.isWhole := io.in.isWhole()
+  io.round := io.in.round()
+}
+
+class FixedRing1Tester(c: FixedRing1) extends DspTester(c) {
+  val increment: Double = if(c.binaryPoint == 0) 1.0 else 1.0 / (1 << c.binaryPoint)
+  println(s"Increment is $increment")
+  for(i <- -2.0 to 3.0 by increment) {
+    println(s"Testing value $i")
+
+    dspPoke(c.io.in, i)
+
+    dspExpect(c.io.floor, breeze.numerics.floor(i), s"floor of $i should be ${breeze.numerics.floor(i)}")
+    dspExpect(c.io.ceil, breeze.numerics.ceil(i), s"ceil of $i should be ${breeze.numerics.ceil(i)}")
+    expect(c.io.isWhole, breeze.numerics.floor(i) == i , s"isWhole of $i should be ${breeze.numerics.floor(i) == i}")
+    dspExpect(c.io.round, breeze.numerics.round(i), s"round of $i should be ${breeze.numerics.round(i)}")
+    step(1)
+  }}
+
+class FixedPointSpec extends FreeSpec with Matchers {
+  "FixedPointIsReal functions should work for a number of different precisions" - {
+    for(binaryPoint <- 0 to 4) {
+      s"should work with binary point $binaryPoint" in {
+        dsptools.Driver.execute(() => new FixedRing1(16, binaryPoint = binaryPoint)) { c =>
+          new FixedRing1Tester(c)
+        } should be (true)
+      }
+    }
+  }
+}

--- a/src/test/scala/examples/ParameterizedAdderSpec.scala
+++ b/src/test/scala/examples/ParameterizedAdderSpec.scala
@@ -27,8 +27,8 @@ class ParameterizedAdder[T <: Data:Ring](gen:() => T) extends Module {
 
 class ParameterizedAdderTester[T<:Data:Ring](c: ParameterizedAdder[T]) extends DspTester(c) {
   for {
-    i <- 0.0 to 1.0 by 0.25
-    j <- 0.0 to 4.0 by 0.5
+    i <- -2.0 to 1.0 by 0.25
+    j <- -2.0 to 4.0 by 0.5
   } {
     dspPoke(c.io.a1, i)
     dspPoke(c.io.a2, j)
@@ -58,6 +58,10 @@ class ParameterizedAdderSpec extends FlatSpec with Matchers {
     def getFixed: FixedPoint = FixedPoint(width = 32, binaryPoint = 16)
 
     dsptools.Driver.execute(() => new ParameterizedAdder(getFixed _)) { c =>
+      new ParameterizedAdderTester(c)
+    } should be (true)
+
+    dsptools.Driver.execute(() => new ParameterizedAdder(getFixed _), Array("--backend-name", "verilator")) { c =>
       new ParameterizedAdderTester(c)
     } should be (true)
   }


### PR DESCRIPTION
implements ceil, floor, isWhole, round, does not do toDouble for now
Fix declaration of isWhole in Ops.scala IsRealOps
Tests for above
Maded ParameterizedAdderTester test negative numbers too