### PR TITLE
Verbosetestercleanup

### DIFF
--- a/src/main/scala/dsptools/VerboseDspTesterUtils.scala
+++ b/src/main/scala/dsptools/VerboseDspTesterUtils.scala
@@ -41,7 +41,7 @@ trait VerilogTbDump {
     val dutName = dut.name
 
     tb write s"`timescale ${dsptestersOpt.tbTimeUnitPs}ps / ${dsptestersOpt.tbTimePrecisionPs}ps\n"
-    tb write s"`define CLK_PERIOD ${dsptestersOpt.clkMul}\n"
+    tb write s"\n`define CLK_PERIOD ${dsptestersOpt.clkMul}\n"
     tb write s"`define RESET_TIME ${dsptestersOpt.initTimeUnits}\n"
     tb write s"`define CLK_DELTA ${dsptestersOpt.tbTimePrecisionPs.toDouble/dsptestersOpt.tbTimeUnitPs}\n"
 
@@ -49,9 +49,9 @@ trait VerilogTbDump {
       "\\\n  $display(\"\\t ASSERTION ON %s FAILED @ CYCLE = %d, 0x%h != EXPECTED 0x%h\", " +
       "\\\n  nodeName,cycle,nodeVal,expVal); $stop; end\n\n"
 
-    tb write "module test;\n"
+    tb write "module test;\n\n"
 
-    tb write "  integer cycle = 0;\n"
+    tb write "  integer cycle = 0;\n\n"
 
     tb write "  reg clock = 1;\n"
     tb write "  reg reset = 1;\n"
@@ -65,7 +65,7 @@ trait VerilogTbDump {
       tb write s"  wire$s[${node.getWidth-1}:0] ${name};\n"
     }
 
-    tb write "  always #(`CLOCK_PERIOD/2) clock = ~clock;\n"
+    tb write "\n  always #(`CLOCK_PERIOD/2) clock = ~clock;\n"
 
     tb write "\n  initial begin\n"
     tb write "    #`RESET_TIME\n"
@@ -76,7 +76,7 @@ trait VerilogTbDump {
     tb write "    .clock(clock),\n"
     tb write "    .reset(reset),\n"
     tb write ((inputs ++ outputs).unzip._2 map (name => s"    .${name}(${name})") mkString ",\n")
-    tb write "  );\n\n"
+    tb write ");\n\n"
 
     // Inputs fed delta after clk rising edge; read delta after clk rising edge
     tb write "  initial begin\n"

--- a/src/main/scala/dsptools/VerboseDspTesterUtils.scala
+++ b/src/main/scala/dsptools/VerboseDspTesterUtils.scala
@@ -65,7 +65,7 @@ trait VerilogTbDump {
       tb write s"  wire$s[${node.getWidth-1}:0] ${name};\n"
     }
 
-    tb write "\n  always #(`CLOCK_PERIOD/2) clock = ~clock;\n"
+    tb write "\n  always #(`CLK_PERIOD/2) clock = ~clock;\n"
 
     tb write "\n  initial begin\n"
     tb write "    #`RESET_TIME\n"

--- a/src/main/scala/dsptools/VerboseDspTesterUtils.scala
+++ b/src/main/scala/dsptools/VerboseDspTesterUtils.scala
@@ -40,16 +40,24 @@ trait VerilogTbDump {
   def initVerilogTbFile() {
     val dutName = dut.name
 
+    val resetTime = dsptestersOpt.initTimeUnits
+    val clkDelta = dsptestersOpt.tbTimePrecisionPs.toDouble/dsptestersOpt.tbTimeUnitPs
+
+    tb write s"// Example VCS Command: $$VCS_HOME/bin/vcs -debug_pp -full64 +define+UNIT_DELAY +rad +v2k +vcs+lic+wait " +
+    s"+vc+list +vcs+initreg+random +vcs+dumpvars+out.vcd tb.v ${dutName}.v ... \n"
+    
     tb write s"`timescale ${dsptestersOpt.tbTimeUnitPs}ps / ${dsptestersOpt.tbTimePrecisionPs}ps\n"
     tb write s"\n`define CLK_PERIOD ${dsptestersOpt.clkMul}\n"
-    tb write s"`define RESET_TIME ${dsptestersOpt.initTimeUnits}\n"
-    tb write s"`define CLK_DELTA ${dsptestersOpt.tbTimePrecisionPs.toDouble/dsptestersOpt.tbTimeUnitPs}\n"
+    tb write s"\n`define HALF_CLK_PERIOD ${dsptestersOpt.clkMul.toDouble/2}\n"
+    tb write s"`define RESET_TIME ${resetTime}\n"
+    tb write s"`define CLK_DELTA ${clkDelta}\n"
+    tb write s"`define INIT_TIME ${clkDelta + resetTime}\n"
 
     tb write "`define expect(nodeName, nodeVal, expVal, cycle) if (nodeVal !== expVal) begin " +
       "\\\n  $display(\"\\t ASSERTION ON %s FAILED @ CYCLE = %d, 0x%h != EXPECTED 0x%h\", " +
       "\\\n  nodeName,cycle,nodeVal,expVal); $stop; end\n\n"
 
-    tb write "module test;\n\n"
+    tb write "module testbench_v;\n\n"
 
     tb write "  integer cycle = 0;\n\n"
 
@@ -65,7 +73,7 @@ trait VerilogTbDump {
       tb write s"  wire$s[${node.getWidth-1}:0] ${name};\n"
     }
 
-    tb write "\n  always #(`CLK_PERIOD/2) clock = ~clock;\n"
+    tb write "\n  always #`HALF_CLK_PERIOD clock = ~clock;\n"
 
     tb write "\n  initial begin\n"
     tb write "    #`RESET_TIME\n"
@@ -80,7 +88,7 @@ trait VerilogTbDump {
 
     // Inputs fed delta after clk rising edge; read delta after clk rising edge
     tb write "  initial begin\n"
-    tb write "    #(`RESET_TIME + `CLK_DELTA) reset = 0;\n"
+    tb write "    #`INIT_TIME reset = 0;\n"
   }
 
   def deleteVerilogTbFile() {

--- a/src/test/resources/TBGoldenModel.v
+++ b/src/test/resources/TBGoldenModel.v
@@ -1,7 +1,4 @@
-package SimpleTB
-
-object TbGoldenModel {
-  val txt = """// Example VCS Command: $VCS_HOME/bin/vcs -debug_pp -full64 +define+UNIT_DELAY +rad +v2k +vcs+lic+wait +vc+list +vcs+initreg+random +vcs+dumpvars+out.vcd tb.v SimpleIOModule.v ... 
+// Example VCS Command: $VCS_HOME/bin/vcs -debug_pp -full64 +define+UNIT_DELAY +rad +v2k +vcs+lic+wait +vc+list +vcs+initreg+random +vcs+dumpvars+out.vcd tb.v SimpleIOModule.v ... 
 `timescale 100ps / 10ps
 
 `define CLK_PERIOD 1
@@ -843,5 +840,4 @@ module testbench_v;
     #`CLK_PERIOD $display("\t **Ran through all test vectors**"); $finish;
 
   end
-endmodule""".stripMargin
-}
+endmodule

--- a/src/test/scala/dsptools/VerboseDspTesterSpec/SimpleTBwGenTypeOption.scala
+++ b/src/test/scala/dsptools/VerboseDspTesterSpec/SimpleTBwGenTypeOption.scala
@@ -1,0 +1,401 @@
+package SimpleTB
+
+import chisel3._
+import chisel3.internal.firrtl.{Width, BinaryPoint}
+import chisel3.experimental.FixedPoint
+import chisel3.util.RegNext
+import breeze.math.Complex
+import dsptools.numbers.{Real, DspReal, DspComplex}
+import dsptools.numbers.implicits._
+import dsptools.{VerboseDspTester, VerboseDspTesterOptionsManager, VerboseDspTesterOptions}
+import org.scalatest.{FlatSpec, Matchers}
+import chisel3.iotesters.TesterOptions
+
+// TODO: Make utility!
+trait EasyPeekPoke {
+
+  self: VerboseDspTester[_] => 
+
+  def feed(d: Data, value: Double) = {
+    d match {
+      case b: Bool => poke(b, if (value == 0.0) 0 else 1)
+      case u: UInt => poke(u, math.abs(value.round).toInt)
+      case r => dspPoke(r, value)
+    }
+  }
+  def feed(d: DspComplex[_], value: Complex) = dspPoke(d, value)
+
+  // TB Debug only [otherwise, just use expect for any *real* tb!]
+  def checkP(d: Data, value: Double) {
+    d match {
+      case b: Bool => peek(b)
+      case u: UInt => peek(u)
+      case r => dspPeek(r)
+    }
+    // SInts are perfect in this case b/c they're just passed through (no loss of precision)
+    d match {
+      case s: SInt => fixTolLSBs.withValue(0) {
+        check(d, value)
+      }
+      case _ => check(d, value)
+    }
+  }
+  def checkP(d: DspComplex[_], value: Complex) = {
+    dspPeek(d)
+    d.real match {
+      case s: SInt => fixTolLSBs.withValue(0) {
+        check(d, value)
+      }
+      case _ => check(d, value)
+    }
+  }
+
+  // TODO: Add runtime tolerance change here as a shortcut?
+  def check(d: Data, value: Double) {
+    d match {
+      case b: Bool => expect(b, if (value == 0.0) 0 else 1)
+      case u: UInt => expect(u, math.abs(value.round).toInt)
+      case r => dspExpect(r, value)
+    }
+  }
+  def check(d: DspComplex[_], value: Complex) = dspExpect(d, value)
+}
+
+case class TestParams(
+    val smallW: Int = 8,
+    val bigW: Int = 16,
+    val smallBP: Int = 4,
+    val bigBP: Int = 8,
+    val posLit: Double = 3.3,
+    val negLit: Double = -3.3,
+    val lutVals: Seq[Double] = Seq(-3.3, -2.2, -1.1, -0.55, -0.4, 0.4, 0.55, 1.1, 2.2, 3.3)) {
+
+  val genLongF = FixedPoint(bigW.W, bigBP.BP)
+  val genShortF = FixedPoint(smallW.W, smallBP.BP)
+  val genLongS = SInt(bigW.W)
+  val genShortS = SInt(smallW.W)
+  val genR = DspReal()
+  val vecLen = lutVals.length
+
+}
+
+class DataTypeBundle[R <: Data:Real](genType: R, width: Width, binaryPoint: BinaryPoint) extends Bundle {
+  val gen = genType.chiselCloneType
+  val s = SInt(width)
+  val f = FixedPoint(width, binaryPoint)
+  val u = UInt(width)
+  override def cloneType: this.type = new DataTypeBundle(genType, width, binaryPoint).asInstanceOf[this.type]
+}
+
+class Interface[R <: Data:Real](genShort: R, genLong: R, includeR: Boolean, p: TestParams) extends Bundle {
+
+  val smallW = p.smallW.W
+  val bigW = p.bigW.W
+  val smallBP = p.smallBP.BP
+  val bigBP = p.bigBP.BP
+  val vecLen = p.vecLen
+
+  val r = if (includeR) Some(DspReal()) else None
+  val b = Bool()
+  val cGenL = DspComplex(genLong)
+  val cFS = DspComplex(FixedPoint(bigW, smallBP))
+  val cR = if (includeR) Some(DspComplex(DspReal())) else None
+
+  val short = new DataTypeBundle(genShort, smallW, smallBP)
+  val long = new DataTypeBundle(genLong, bigW, bigBP)
+
+  val vU = Vec(vecLen, UInt(smallW))
+  val vS = Vec(vecLen, SInt(smallW))  
+  val vF = Vec(vecLen, FixedPoint(bigW, smallBP))  
+  
+  override def cloneType: this.type = new Interface(genShort, genLong, includeR, p).asInstanceOf[this.type]
+}
+
+class SimpleIOModule[R <: Data:Real](genShort: R, genLong: R, val includeR: Boolean, val p: TestParams) 
+    extends Module {
+
+  val io = IO(new Bundle {
+    val i = Input(new Interface(genShort, genLong, includeR, p))
+    val o = Output(new Interface(genShort, genLong, includeR, p)) }) 
+
+  // Crossed sizes on purpose (to make sure Fixed point was interpreted correctly)
+  io.o.long <> RegNext(io.i.short) 
+  io.o.short <> RegNext(io.i.long)
+
+  if (includeR) io.o.r.get := RegNext(io.i.r.get)
+  io.o.b := RegNext(io.i.b)
+  io.o.cGenL := RegNext(io.i.cGenL)
+  io.o.cFS := RegNext(io.i.cFS)
+  if (includeR) io.o.cR.get := RegNext(io.i.cR.get)
+
+  io.o.vU := RegNext(io.i.vU)
+  io.o.vS := RegNext(io.i.vS)
+  io.o.vF := RegNext(io.i.vF)
+
+}
+
+class SimpleLitModule[R <: Data:Real](genShort: R, genLong: R, val includeR: Boolean, val p: TestParams) 
+    extends Module {
+
+  val posLit = p.posLit
+  val negLit = p.negLit
+  val lutVals = p.lutVals
+  val bp = p.smallBP
+
+  val io = IO(new Bundle {
+    val i = Input(new Interface(genShort, genLong, includeR, p))
+    val o = Output(new Interface(genShort, genLong, includeR, p)) }) 
+
+  val litRP = if (includeR) Some(DspReal(posLit)) else None
+  val litRN = if (includeR) Some(DspReal(negLit)) else None
+
+  val pos = new Bundle {
+    val litG = genShort.double2T(posLit)
+    val litS = posLit.round.toInt.S
+    val litF = FixedPoint.fromDouble(posLit, binaryPoint = bp)
+  }
+
+  val neg = new Bundle {
+    val litG = genShort.double2T(negLit)
+    val litS = negLit.round.toInt.S
+    val litF = FixedPoint.fromDouble(negLit, binaryPoint = bp)
+  }
+
+  val litB = Bool(true)
+  val litU = posLit.round.toInt.U
+  val litC = DspComplex(
+      FixedPoint.fromDouble(posLit, binaryPoint = bp), 
+      FixedPoint.fromDouble(negLit, binaryPoint = bp))
+  
+
+  val lutGenSeq = lutVals map {x => genShort.double2TFixedWidth(x)}
+  val lutSSeq = lutVals map (_.round.toInt.S(p.smallW.W))
+
+  val lutGen = Vec(lutGenSeq)
+  val lutS = Vec(lutSSeq)
+
+  io.o.short.gen := lutGen(io.i.short.u)
+  io.o.short.s := lutS(io.i.short.u)
+
+}
+
+class PassIOTester[R <: Data:Real](c: SimpleIOModule[R]) extends VerboseDspTester(c) with EasyPeekPoke {
+  
+  val lutVals = c.p.lutVals
+  val io = c.io
+
+  // SInts auto rounded; UInts auto absolute valued + rounded
+  (lutVals :+ lutVals.head).zipWithIndex foreach { case (value, i) => {
+    (io.i.short.elements.unzip._2 ++ io.i.long.elements.unzip._2) foreach  { a => feed(a, value) }
+    val complexVal = Complex(value, -value)
+    if (c.includeR) feed(io.i.r.get, value)
+    feed(io.i.b, value)
+    feed(io.i.cGenL, complexVal)
+    feed(io.i.cFS, complexVal)
+    if (c.includeR) feed(io.i.cR.get, complexVal)
+    if (i != 0) {
+      val prevVal = lutVals(i-1)
+      val prevComplexVal = Complex(prevVal, -prevVal)
+      io.o.short.elements.unzip._2 foreach { a => checkP(a, prevVal) }
+      if (c.includeR) checkP(io.o.r.get, prevVal)
+      checkP(io.o.b, prevVal)
+      checkP(io.o.cGenL, prevComplexVal)
+      checkP(io.o.cFS, prevComplexVal)
+      if (c.includeR) checkP(io.o.cR.get, prevComplexVal)
+      // Since long outputs come from short inputs, the tolerance must match that of smallBP
+      fixTolLSBs.withValue(c.p.bigBP - c.p.smallBP + fixTolLSBs.value) {
+        io.o.long.elements.unzip._2 foreach { a => checkP(a, prevVal) }
+      }
+    }
+    step(1)
+  }}
+
+  lutVals.zipWithIndex foreach { case (value, i) => {
+    feed(io.i.vU(i), value)
+    feed(io.i.vS(i), value)
+    feed(io.i.vF(i), value)
+  }}
+
+  step(5)
+  lutVals.reverse.zipWithIndex foreach { case (value, i) => {
+    feed(io.i.vU(i), value)
+    feed(io.i.vS(i), value)
+    feed(io.i.vF(i), value)
+    checkP(io.o.vU(i), lutVals(i))
+    checkP(io.o.vS(i), lutVals(i))
+    checkP(io.o.vF(i), lutVals(i))
+  }}
+
+  step(5)
+  lutVals.reverse.zipWithIndex foreach { case (value, i) => {
+    feed(io.i.vU(i), 0)
+    feed(io.i.vS(i), 0)
+    feed(io.i.vF(i), 0)
+    checkP(io.o.vU(i), value)
+    checkP(io.o.vS(i), value)
+    checkP(io.o.vF(i), value)
+  }}
+
+  peek(io.o.vU)
+  peek(io.o.vS)
+
+}
+
+class PassLitTester[R <: Data:Real](c: SimpleLitModule[R]) extends VerboseDspTester(c) with EasyPeekPoke {
+  
+  val posLit = c.posLit
+  val negLit = c.negLit
+  val lutVals = c.lutVals
+
+  if (c.includeR) {
+    checkP(c.litRP.get, posLit)
+    checkP(c.litRN.get, negLit)
+  }
+  
+  // dspExpect properly rounds doubles to ints for SInt
+  c.pos.elements foreach { case (s, d) => checkP(d, posLit) }
+  c.neg.elements foreach { case (s, d) => checkP(d, negLit) }
+
+  checkP(c.litB, 1)
+  checkP(c.litU, posLit)
+
+  checkP(c.litC, Complex(posLit, negLit))
+
+  // peek(c.lutS) doesn't work -- can't peek elements of Vec[Lit]
+  // dspExpect auto rounds SInts
+  c.lutSSeq.zipWithIndex foreach { case (x, i) => checkP(x, lutVals(i)) }
+  c.lutGenSeq.zipWithIndex foreach { case (x, i) => checkP(x, lutVals(i)) }
+
+  c.lutVals.zipWithIndex foreach { case (x, i) => {
+    poke(c.io.i.short.u, i)
+    checkP(c.io.o.short.gen, x)
+
+    // How to change expect tolerance (for Lits; SInts should match exactly)
+    // dspExpect automatically rounds when data is SInt (whereas expect doesn't)
+    fixTolLSBs.withValue(0) {
+      checkP(c.io.o.short.s, x)
+    }
+
+  }}
+
+  dspPeek(c.lutGenSeq(0))
+  dspPeek(c.lutSSeq(0))
+}
+
+class FailLitTester[R <: Data:Real](c: SimpleLitModule[R]) extends VerboseDspTester(c) {
+  
+  val posLit = c.posLit
+  val negLit = c.negLit
+  val lutVals = c.lutVals
+
+  c.pos.elements foreach { case (s, d) => {
+    d match {
+      case f: FixedPoint => dspExpect(f, posLit)
+      case _ => } } }
+
+  c.neg.elements foreach { case (s, d) => {
+    d match {
+      case f: FixedPoint => dspExpect(f, negLit)
+      case _ => } } }
+
+  dspExpect(c.litC, Complex(posLit, negLit))
+
+  c.lutGenSeq.zipWithIndex foreach { case (x, i) => {
+    dspExpect(x, lutVals(i)) }}
+
+  c.lutVals.zipWithIndex foreach { case (x, i) => {
+    poke(c.io.i.short.u, i)
+    dspExpect(c.io.o.short.gen, x)
+  }}
+
+}
+
+object TestSetup {
+  val p = TestParams()
+
+  val testerOptionsGlobal = TesterOptions(
+      isVerbose = false,
+      displayBase = 16,
+      backendName = "verilator",
+      isGenVerilog = true)
+
+  val optionsPass = new VerboseDspTesterOptionsManager {
+      verboseDspTesterOptions = VerboseDspTesterOptions(
+          fixTolLSBs = 1,
+          genVerilogTb = false,
+          isVerbose = true)
+      testerOptions = testerOptionsGlobal
+    }
+
+  val optionsFail = new VerboseDspTesterOptionsManager {
+    verboseDspTesterOptions = optionsPass.verboseDspTesterOptions.copy(fixTolLSBs = 0)
+    testerOptions = testerOptionsGlobal
+  }
+
+  val optionsPassTB = new VerboseDspTesterOptionsManager {
+    verboseDspTesterOptions = optionsPass.verboseDspTesterOptions.copy(genVerilogTb = true)
+    testerOptions = testerOptionsGlobal
+  }
+
+}
+
+class SimpleTBSpec extends FlatSpec with Matchers {
+
+  val p = TestSetup.p
+  val optionsPass = TestSetup.optionsPass
+  val optionsPassTB = TestSetup.optionsPassTB
+  val optionsFail = TestSetup.optionsFail
+
+  behavior of "simple module lits"
+
+  it should "properly read lits with gen = sint (reals rounded) and expect tolerance set to 1 bit" in {
+    dsptools.Driver.execute(() => new SimpleLitModule(p.genShortS, p.genLongS, includeR = true, p), optionsPass) { c =>
+      new PassLitTester(c)
+    } should be (true)
+  }
+
+  it should "properly read lits with gen = fixed and expect tolerance set to 1 bit " +
+      "(even with finite fractional bits)" in {
+    dsptools.Driver.execute(() => new SimpleLitModule(p.genShortF, p.genLongF, includeR = true, p), optionsPass) { c =>
+      new PassLitTester(c)
+    } should be (true)
+  }
+
+  it should "*fail* to read all lits with gen = fixed when expect tolerance is set to 0 bits " + 
+      "(due to not having enough fractional bits to represent #s)" in {
+    dsptools.Driver.execute(() => new SimpleLitModule(p.genShortF, p.genLongF, includeR = true, p), optionsFail) { c =>
+      new FailLitTester(c)
+    } should be (false)
+  }
+
+  behavior of "simple module registered io"
+
+  it should "properly poke/peek io delayed 1 cycle with gen = sint (reals rounded) " +
+      "and expect tolerance set to 1 bit" in {
+    dsptools.Driver.execute(() => new SimpleIOModule(p.genShortS, p.genLongS, includeR = true, p), optionsPass) { c =>
+      new PassIOTester(c)
+    } should be (true)
+  }
+
+  it should "properly poke/peek io delayed 1 cycle with gen = fixed and expect tolerance set to 1 bit" in {
+    dsptools.Driver.execute(() => new SimpleIOModule(p.genShortF, p.genLongF, includeR = true, p), optionsPass) { c =>
+      new PassIOTester(c)
+    } should be (true)
+  }
+
+  it should "properly poke/peek io delayed 1 cycle with gen = fixed + print TB (no reals)" in {
+    this.synchronized {
+      var tbFileLoc: String = ""
+      dsptools.Driver.execute(() => new SimpleIOModule(p.genShortF, p.genLongF, includeR = false, p), 
+          optionsPassTB) { c => {
+        val tester = new PassIOTester(c)
+        tbFileLoc = tester.tbFileName
+        tester
+      } } should be (true)
+      def read(file: String) = scala.io.Source.fromFile(file).getLines.mkString("\n")
+      val tbTxt = read(tbFileLoc).stripMargin
+      require(tbTxt == TbGoldenModel.txt, "Test bench incorrect! (compared against simulated model)")
+    }
+  }
+
+}

--- a/src/test/scala/dsptools/VerboseDspTesterSpec/SimpleTBwGenTypeOption.scala
+++ b/src/test/scala/dsptools/VerboseDspTesterSpec/SimpleTBwGenTypeOption.scala
@@ -392,9 +392,13 @@ class SimpleTBSpec extends FlatSpec with Matchers {
         tbFileLoc = tester.tbFileName
         tester
       } } should be (true)
-      def read(file: String) = scala.io.Source.fromFile(file).getLines.mkString("\n")
-      val tbTxt = read(tbFileLoc).stripMargin
-      require(tbTxt == TbGoldenModel.txt, "Test bench incorrect! (compared against simulated model)")
+      val tbTxt = scala.io.Source.fromFile(tbFileLoc).getLines
+      // This is a lot easier in Scala 2.12.x
+      val resourceGoldenModel = getClass.getResourceAsStream("/TBGoldenModel.v")
+      val TbGoldenModelTxt = scala.io.Source.fromInputStream(resourceGoldenModel).getLines
+      TbGoldenModelTxt.zip(tbTxt) foreach { case (expected, in) =>
+        (expected == in) should be (true)
+      }
     }
   }
 

--- a/src/test/scala/dsptools/VerboseDspTesterSpec/TBGoldenModel.scala
+++ b/src/test/scala/dsptools/VerboseDspTesterSpec/TBGoldenModel.scala
@@ -1,0 +1,847 @@
+package SimpleTB
+
+object TbGoldenModel {
+  val txt = """// Example VCS Command: $VCS_HOME/bin/vcs -debug_pp -full64 +define+UNIT_DELAY +rad +v2k +vcs+lic+wait +vc+list +vcs+initreg+random +vcs+dumpvars+out.vcd tb.v SimpleIOModule.v ... 
+`timescale 100ps / 10ps
+
+`define CLK_PERIOD 1
+
+`define HALF_CLK_PERIOD 0.5
+`define RESET_TIME 5
+`define CLK_DELTA 0.1
+`define INIT_TIME 5.1
+`define expect(nodeName, nodeVal, expVal, cycle) if (nodeVal !== expVal) begin \
+  $display("\t ASSERTION ON %s FAILED @ CYCLE = %d, 0x%h != EXPECTED 0x%h", \
+  nodeName,cycle,nodeVal,expVal); $stop; end
+
+module testbench_v;
+
+  integer cycle = 0;
+
+  reg clock = 1;
+  reg reset = 1;
+  reg signed [15:0] io_i_vF_0 = 0;
+  reg signed [15:0] io_i_vF_1 = 0;
+  reg signed [15:0] io_i_vF_2 = 0;
+  reg signed [15:0] io_i_vF_3 = 0;
+  reg signed [15:0] io_i_vF_4 = 0;
+  reg signed [15:0] io_i_vF_5 = 0;
+  reg signed [15:0] io_i_vF_6 = 0;
+  reg signed [15:0] io_i_vF_7 = 0;
+  reg signed [15:0] io_i_vF_8 = 0;
+  reg signed [15:0] io_i_vF_9 = 0;
+  reg signed [7:0] io_i_vS_0 = 0;
+  reg signed [7:0] io_i_vS_1 = 0;
+  reg signed [7:0] io_i_vS_2 = 0;
+  reg signed [7:0] io_i_vS_3 = 0;
+  reg signed [7:0] io_i_vS_4 = 0;
+  reg signed [7:0] io_i_vS_5 = 0;
+  reg signed [7:0] io_i_vS_6 = 0;
+  reg signed [7:0] io_i_vS_7 = 0;
+  reg signed [7:0] io_i_vS_8 = 0;
+  reg signed [7:0] io_i_vS_9 = 0;
+  reg[7:0] io_i_vU_0 = 0;
+  reg[7:0] io_i_vU_1 = 0;
+  reg[7:0] io_i_vU_2 = 0;
+  reg[7:0] io_i_vU_3 = 0;
+  reg[7:0] io_i_vU_4 = 0;
+  reg[7:0] io_i_vU_5 = 0;
+  reg[7:0] io_i_vU_6 = 0;
+  reg[7:0] io_i_vU_7 = 0;
+  reg[7:0] io_i_vU_8 = 0;
+  reg[7:0] io_i_vU_9 = 0;
+  reg[15:0] io_i_long_u = 0;
+  reg signed [15:0] io_i_long_f = 0;
+  reg signed [15:0] io_i_long_s = 0;
+  reg signed [15:0] io_i_long_gen = 0;
+  reg[7:0] io_i_short_u = 0;
+  reg signed [7:0] io_i_short_f = 0;
+  reg signed [7:0] io_i_short_s = 0;
+  reg signed [7:0] io_i_short_gen = 0;
+  reg signed [15:0] io_i_cFS_imaginary = 0;
+  reg signed [15:0] io_i_cFS_real = 0;
+  reg signed [15:0] io_i_cGenL_imaginary = 0;
+  reg signed [15:0] io_i_cGenL_real = 0;
+  reg[0:0] io_i_b = 0;
+  wire signed [15:0] io_o_vF_0;
+  wire signed [15:0] io_o_vF_1;
+  wire signed [15:0] io_o_vF_2;
+  wire signed [15:0] io_o_vF_3;
+  wire signed [15:0] io_o_vF_4;
+  wire signed [15:0] io_o_vF_5;
+  wire signed [15:0] io_o_vF_6;
+  wire signed [15:0] io_o_vF_7;
+  wire signed [15:0] io_o_vF_8;
+  wire signed [15:0] io_o_vF_9;
+  wire signed [7:0] io_o_vS_0;
+  wire signed [7:0] io_o_vS_1;
+  wire signed [7:0] io_o_vS_2;
+  wire signed [7:0] io_o_vS_3;
+  wire signed [7:0] io_o_vS_4;
+  wire signed [7:0] io_o_vS_5;
+  wire signed [7:0] io_o_vS_6;
+  wire signed [7:0] io_o_vS_7;
+  wire signed [7:0] io_o_vS_8;
+  wire signed [7:0] io_o_vS_9;
+  wire[7:0] io_o_vU_0;
+  wire[7:0] io_o_vU_1;
+  wire[7:0] io_o_vU_2;
+  wire[7:0] io_o_vU_3;
+  wire[7:0] io_o_vU_4;
+  wire[7:0] io_o_vU_5;
+  wire[7:0] io_o_vU_6;
+  wire[7:0] io_o_vU_7;
+  wire[7:0] io_o_vU_8;
+  wire[7:0] io_o_vU_9;
+  wire[15:0] io_o_long_u;
+  wire signed [15:0] io_o_long_f;
+  wire signed [15:0] io_o_long_s;
+  wire signed [15:0] io_o_long_gen;
+  wire[7:0] io_o_short_u;
+  wire signed [7:0] io_o_short_f;
+  wire signed [7:0] io_o_short_s;
+  wire signed [7:0] io_o_short_gen;
+  wire signed [15:0] io_o_cFS_imaginary;
+  wire signed [15:0] io_o_cFS_real;
+  wire signed [15:0] io_o_cGenL_imaginary;
+  wire signed [15:0] io_o_cGenL_real;
+  wire[0:0] io_o_b;
+
+  always #`HALF_CLK_PERIOD clock = ~clock;
+
+  initial begin
+    #`RESET_TIME
+    forever #`CLK_PERIOD cycle = cycle + 1;
+  end
+
+  SimpleIOModule SimpleIOModule(
+    .clock(clock),
+    .reset(reset),
+    .io_i_vF_0(io_i_vF_0),
+    .io_i_vF_1(io_i_vF_1),
+    .io_i_vF_2(io_i_vF_2),
+    .io_i_vF_3(io_i_vF_3),
+    .io_i_vF_4(io_i_vF_4),
+    .io_i_vF_5(io_i_vF_5),
+    .io_i_vF_6(io_i_vF_6),
+    .io_i_vF_7(io_i_vF_7),
+    .io_i_vF_8(io_i_vF_8),
+    .io_i_vF_9(io_i_vF_9),
+    .io_i_vS_0(io_i_vS_0),
+    .io_i_vS_1(io_i_vS_1),
+    .io_i_vS_2(io_i_vS_2),
+    .io_i_vS_3(io_i_vS_3),
+    .io_i_vS_4(io_i_vS_4),
+    .io_i_vS_5(io_i_vS_5),
+    .io_i_vS_6(io_i_vS_6),
+    .io_i_vS_7(io_i_vS_7),
+    .io_i_vS_8(io_i_vS_8),
+    .io_i_vS_9(io_i_vS_9),
+    .io_i_vU_0(io_i_vU_0),
+    .io_i_vU_1(io_i_vU_1),
+    .io_i_vU_2(io_i_vU_2),
+    .io_i_vU_3(io_i_vU_3),
+    .io_i_vU_4(io_i_vU_4),
+    .io_i_vU_5(io_i_vU_5),
+    .io_i_vU_6(io_i_vU_6),
+    .io_i_vU_7(io_i_vU_7),
+    .io_i_vU_8(io_i_vU_8),
+    .io_i_vU_9(io_i_vU_9),
+    .io_i_long_u(io_i_long_u),
+    .io_i_long_f(io_i_long_f),
+    .io_i_long_s(io_i_long_s),
+    .io_i_long_gen(io_i_long_gen),
+    .io_i_short_u(io_i_short_u),
+    .io_i_short_f(io_i_short_f),
+    .io_i_short_s(io_i_short_s),
+    .io_i_short_gen(io_i_short_gen),
+    .io_i_cFS_imaginary(io_i_cFS_imaginary),
+    .io_i_cFS_real(io_i_cFS_real),
+    .io_i_cGenL_imaginary(io_i_cGenL_imaginary),
+    .io_i_cGenL_real(io_i_cGenL_real),
+    .io_i_b(io_i_b),
+    .io_o_vF_0(io_o_vF_0),
+    .io_o_vF_1(io_o_vF_1),
+    .io_o_vF_2(io_o_vF_2),
+    .io_o_vF_3(io_o_vF_3),
+    .io_o_vF_4(io_o_vF_4),
+    .io_o_vF_5(io_o_vF_5),
+    .io_o_vF_6(io_o_vF_6),
+    .io_o_vF_7(io_o_vF_7),
+    .io_o_vF_8(io_o_vF_8),
+    .io_o_vF_9(io_o_vF_9),
+    .io_o_vS_0(io_o_vS_0),
+    .io_o_vS_1(io_o_vS_1),
+    .io_o_vS_2(io_o_vS_2),
+    .io_o_vS_3(io_o_vS_3),
+    .io_o_vS_4(io_o_vS_4),
+    .io_o_vS_5(io_o_vS_5),
+    .io_o_vS_6(io_o_vS_6),
+    .io_o_vS_7(io_o_vS_7),
+    .io_o_vS_8(io_o_vS_8),
+    .io_o_vS_9(io_o_vS_9),
+    .io_o_vU_0(io_o_vU_0),
+    .io_o_vU_1(io_o_vU_1),
+    .io_o_vU_2(io_o_vU_2),
+    .io_o_vU_3(io_o_vU_3),
+    .io_o_vU_4(io_o_vU_4),
+    .io_o_vU_5(io_o_vU_5),
+    .io_o_vU_6(io_o_vU_6),
+    .io_o_vU_7(io_o_vU_7),
+    .io_o_vU_8(io_o_vU_8),
+    .io_o_vU_9(io_o_vU_9),
+    .io_o_long_u(io_o_long_u),
+    .io_o_long_f(io_o_long_f),
+    .io_o_long_s(io_o_long_s),
+    .io_o_long_gen(io_o_long_gen),
+    .io_o_short_u(io_o_short_u),
+    .io_o_short_f(io_o_short_f),
+    .io_o_short_s(io_o_short_s),
+    .io_o_short_gen(io_o_short_gen),
+    .io_o_cFS_imaginary(io_o_cFS_imaginary),
+    .io_o_cFS_real(io_o_cFS_real),
+    .io_o_cGenL_imaginary(io_o_cGenL_imaginary),
+    .io_o_cGenL_real(io_o_cGenL_real),
+    .io_o_b(io_o_b));
+
+  initial begin
+    #`INIT_TIME reset = 0;
+    io_i_short_u = 2'd3;
+    io_i_short_f = -53;
+    io_i_short_s = -3;
+    io_i_short_gen = -53;
+    io_i_long_u = 2'd3;
+    io_i_long_f = -845;
+    io_i_long_s = -3;
+    io_i_long_gen = -845;
+    io_i_b = 1'd1;
+    io_i_cGenL_real = -845;
+    io_i_cGenL_imaginary = 10'd845;
+    io_i_cFS_real = -53;
+    io_i_cFS_imaginary = 6'd53;
+    #(1*`CLK_PERIOD)     io_i_short_u = 2'd2;
+    io_i_short_f = -35;
+    io_i_short_s = -2;
+    io_i_short_gen = -35;
+    io_i_long_u = 2'd2;
+    io_i_long_f = -563;
+    io_i_long_s = -2;
+    io_i_long_gen = -563;
+    io_i_b = 1'd1;
+    io_i_cGenL_real = -563;
+    io_i_cGenL_imaginary = 10'd563;
+    io_i_cFS_real = -35;
+    io_i_cFS_imaginary = 6'd35;
+    `expect("io_o_short_u",io_o_short_u,3,cycle)
+    `expect("io_o_short_u",io_o_short_u,3,cycle)
+    `expect("io_o_short_f",io_o_short_f,-53,cycle)
+    `expect("io_o_short_f",io_o_short_f,-53,cycle)
+    `expect("io_o_short_s",io_o_short_s,-3,cycle)
+    `expect("io_o_short_s",io_o_short_s,-3,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,-53,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,-53,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,-845,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,845,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,-845,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,845,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,-53,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,53,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,-53,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,53,cycle)
+    `expect("io_o_long_u",io_o_long_u,3,cycle)
+    `expect("io_o_long_u",io_o_long_u,3,cycle)
+    `expect("io_o_long_f",io_o_long_f,-848,cycle)
+    `expect("io_o_long_f",io_o_long_f,-848,cycle)
+    `expect("io_o_long_s",io_o_long_s,-3,cycle)
+    `expect("io_o_long_s",io_o_long_s,-3,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,-848,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,-848,cycle)
+    #(1*`CLK_PERIOD)     io_i_short_u = 1'd1;
+    io_i_short_f = -18;
+    io_i_short_s = -1;
+    io_i_short_gen = -18;
+    io_i_long_u = 1'd1;
+    io_i_long_f = -282;
+    io_i_long_s = -1;
+    io_i_long_gen = -282;
+    io_i_b = 1'd1;
+    io_i_cGenL_real = -282;
+    io_i_cGenL_imaginary = 9'd282;
+    io_i_cFS_real = -18;
+    io_i_cFS_imaginary = 5'd18;
+    `expect("io_o_short_u",io_o_short_u,2,cycle)
+    `expect("io_o_short_u",io_o_short_u,2,cycle)
+    `expect("io_o_short_f",io_o_short_f,-36,cycle)
+    `expect("io_o_short_f",io_o_short_f,-36,cycle)
+    `expect("io_o_short_s",io_o_short_s,-2,cycle)
+    `expect("io_o_short_s",io_o_short_s,-2,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,-36,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,-36,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,-563,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,563,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,-563,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,563,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,-35,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,35,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,-35,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,35,cycle)
+    `expect("io_o_long_u",io_o_long_u,2,cycle)
+    `expect("io_o_long_u",io_o_long_u,2,cycle)
+    `expect("io_o_long_f",io_o_long_f,-560,cycle)
+    `expect("io_o_long_f",io_o_long_f,-560,cycle)
+    `expect("io_o_long_s",io_o_long_s,-2,cycle)
+    `expect("io_o_long_s",io_o_long_s,-2,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,-560,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,-560,cycle)
+    #(1*`CLK_PERIOD)     io_i_short_u = 1'd1;
+    io_i_short_f = -9;
+    io_i_short_s = -1;
+    io_i_short_gen = -9;
+    io_i_long_u = 1'd1;
+    io_i_long_f = -141;
+    io_i_long_s = -1;
+    io_i_long_gen = -141;
+    io_i_b = 1'd1;
+    io_i_cGenL_real = -141;
+    io_i_cGenL_imaginary = 8'd141;
+    io_i_cFS_real = -9;
+    io_i_cFS_imaginary = 4'd9;
+    `expect("io_o_short_u",io_o_short_u,1,cycle)
+    `expect("io_o_short_u",io_o_short_u,1,cycle)
+    `expect("io_o_short_f",io_o_short_f,-18,cycle)
+    `expect("io_o_short_f",io_o_short_f,-18,cycle)
+    `expect("io_o_short_s",io_o_short_s,-1,cycle)
+    `expect("io_o_short_s",io_o_short_s,-1,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,-18,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,-18,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,-282,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,282,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,-282,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,282,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,-18,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,18,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,-18,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,18,cycle)
+    `expect("io_o_long_u",io_o_long_u,1,cycle)
+    `expect("io_o_long_u",io_o_long_u,1,cycle)
+    `expect("io_o_long_f",io_o_long_f,-288,cycle)
+    `expect("io_o_long_f",io_o_long_f,-288,cycle)
+    `expect("io_o_long_s",io_o_long_s,-1,cycle)
+    `expect("io_o_long_s",io_o_long_s,-1,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,-288,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,-288,cycle)
+    #(1*`CLK_PERIOD)     io_i_short_u = 1'd0;
+    io_i_short_f = -6;
+    io_i_short_s = 1'd0;
+    io_i_short_gen = -6;
+    io_i_long_u = 1'd0;
+    io_i_long_f = -102;
+    io_i_long_s = 1'd0;
+    io_i_long_gen = -102;
+    io_i_b = 1'd1;
+    io_i_cGenL_real = -102;
+    io_i_cGenL_imaginary = 7'd102;
+    io_i_cFS_real = -6;
+    io_i_cFS_imaginary = 3'd6;
+    `expect("io_o_short_u",io_o_short_u,1,cycle)
+    `expect("io_o_short_u",io_o_short_u,1,cycle)
+    `expect("io_o_short_f",io_o_short_f,-9,cycle)
+    `expect("io_o_short_f",io_o_short_f,-9,cycle)
+    `expect("io_o_short_s",io_o_short_s,-1,cycle)
+    `expect("io_o_short_s",io_o_short_s,-1,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,-9,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,-9,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,-141,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,141,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,-141,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,141,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,-9,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,9,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,-9,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,9,cycle)
+    `expect("io_o_long_u",io_o_long_u,1,cycle)
+    `expect("io_o_long_u",io_o_long_u,1,cycle)
+    `expect("io_o_long_f",io_o_long_f,-144,cycle)
+    `expect("io_o_long_f",io_o_long_f,-144,cycle)
+    `expect("io_o_long_s",io_o_long_s,-1,cycle)
+    `expect("io_o_long_s",io_o_long_s,-1,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,-144,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,-144,cycle)
+    #(1*`CLK_PERIOD)     io_i_short_u = 1'd0;
+    io_i_short_f = 3'd6;
+    io_i_short_s = 1'd0;
+    io_i_short_gen = 3'd6;
+    io_i_long_u = 1'd0;
+    io_i_long_f = 7'd102;
+    io_i_long_s = 1'd0;
+    io_i_long_gen = 7'd102;
+    io_i_b = 1'd1;
+    io_i_cGenL_real = 7'd102;
+    io_i_cGenL_imaginary = -102;
+    io_i_cFS_real = 3'd6;
+    io_i_cFS_imaginary = -6;
+    `expect("io_o_short_u",io_o_short_u,0,cycle)
+    `expect("io_o_short_u",io_o_short_u,0,cycle)
+    `expect("io_o_short_f",io_o_short_f,-7,cycle)
+    `expect("io_o_short_f",io_o_short_f,-7,cycle)
+    `expect("io_o_short_s",io_o_short_s,0,cycle)
+    `expect("io_o_short_s",io_o_short_s,0,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,-7,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,-7,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,-102,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,102,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,-102,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,102,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,-6,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,6,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,-6,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,6,cycle)
+    `expect("io_o_long_u",io_o_long_u,0,cycle)
+    `expect("io_o_long_u",io_o_long_u,0,cycle)
+    `expect("io_o_long_f",io_o_long_f,-96,cycle)
+    `expect("io_o_long_f",io_o_long_f,-96,cycle)
+    `expect("io_o_long_s",io_o_long_s,0,cycle)
+    `expect("io_o_long_s",io_o_long_s,0,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,-96,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,-96,cycle)
+    #(1*`CLK_PERIOD)     io_i_short_u = 1'd1;
+    io_i_short_f = 4'd9;
+    io_i_short_s = 1'd1;
+    io_i_short_gen = 4'd9;
+    io_i_long_u = 1'd1;
+    io_i_long_f = 8'd141;
+    io_i_long_s = 1'd1;
+    io_i_long_gen = 8'd141;
+    io_i_b = 1'd1;
+    io_i_cGenL_real = 8'd141;
+    io_i_cGenL_imaginary = -141;
+    io_i_cFS_real = 4'd9;
+    io_i_cFS_imaginary = -9;
+    `expect("io_o_short_u",io_o_short_u,0,cycle)
+    `expect("io_o_short_u",io_o_short_u,0,cycle)
+    `expect("io_o_short_f",io_o_short_f,6,cycle)
+    `expect("io_o_short_f",io_o_short_f,6,cycle)
+    `expect("io_o_short_s",io_o_short_s,0,cycle)
+    `expect("io_o_short_s",io_o_short_s,0,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,6,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,6,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,102,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,-102,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,102,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,-102,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,6,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,-6,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,6,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,-6,cycle)
+    `expect("io_o_long_u",io_o_long_u,0,cycle)
+    `expect("io_o_long_u",io_o_long_u,0,cycle)
+    `expect("io_o_long_f",io_o_long_f,96,cycle)
+    `expect("io_o_long_f",io_o_long_f,96,cycle)
+    `expect("io_o_long_s",io_o_long_s,0,cycle)
+    `expect("io_o_long_s",io_o_long_s,0,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,96,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,96,cycle)
+    #(1*`CLK_PERIOD)     io_i_short_u = 1'd1;
+    io_i_short_f = 5'd18;
+    io_i_short_s = 1'd1;
+    io_i_short_gen = 5'd18;
+    io_i_long_u = 1'd1;
+    io_i_long_f = 9'd282;
+    io_i_long_s = 1'd1;
+    io_i_long_gen = 9'd282;
+    io_i_b = 1'd1;
+    io_i_cGenL_real = 9'd282;
+    io_i_cGenL_imaginary = -282;
+    io_i_cFS_real = 5'd18;
+    io_i_cFS_imaginary = -18;
+    `expect("io_o_short_u",io_o_short_u,1,cycle)
+    `expect("io_o_short_u",io_o_short_u,1,cycle)
+    `expect("io_o_short_f",io_o_short_f,8,cycle)
+    `expect("io_o_short_f",io_o_short_f,8,cycle)
+    `expect("io_o_short_s",io_o_short_s,1,cycle)
+    `expect("io_o_short_s",io_o_short_s,1,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,8,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,8,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,141,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,-141,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,141,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,-141,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,9,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,-9,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,9,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,-9,cycle)
+    `expect("io_o_long_u",io_o_long_u,1,cycle)
+    `expect("io_o_long_u",io_o_long_u,1,cycle)
+    `expect("io_o_long_f",io_o_long_f,144,cycle)
+    `expect("io_o_long_f",io_o_long_f,144,cycle)
+    `expect("io_o_long_s",io_o_long_s,1,cycle)
+    `expect("io_o_long_s",io_o_long_s,1,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,144,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,144,cycle)
+    #(1*`CLK_PERIOD)     io_i_short_u = 2'd2;
+    io_i_short_f = 6'd35;
+    io_i_short_s = 2'd2;
+    io_i_short_gen = 6'd35;
+    io_i_long_u = 2'd2;
+    io_i_long_f = 10'd563;
+    io_i_long_s = 2'd2;
+    io_i_long_gen = 10'd563;
+    io_i_b = 1'd1;
+    io_i_cGenL_real = 10'd563;
+    io_i_cGenL_imaginary = -563;
+    io_i_cFS_real = 6'd35;
+    io_i_cFS_imaginary = -35;
+    `expect("io_o_short_u",io_o_short_u,1,cycle)
+    `expect("io_o_short_u",io_o_short_u,1,cycle)
+    `expect("io_o_short_f",io_o_short_f,17,cycle)
+    `expect("io_o_short_f",io_o_short_f,17,cycle)
+    `expect("io_o_short_s",io_o_short_s,1,cycle)
+    `expect("io_o_short_s",io_o_short_s,1,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,17,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,17,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,282,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,-282,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,282,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,-282,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,18,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,-18,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,18,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,-18,cycle)
+    `expect("io_o_long_u",io_o_long_u,1,cycle)
+    `expect("io_o_long_u",io_o_long_u,1,cycle)
+    `expect("io_o_long_f",io_o_long_f,288,cycle)
+    `expect("io_o_long_f",io_o_long_f,288,cycle)
+    `expect("io_o_long_s",io_o_long_s,1,cycle)
+    `expect("io_o_long_s",io_o_long_s,1,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,288,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,288,cycle)
+    #(1*`CLK_PERIOD)     io_i_short_u = 2'd3;
+    io_i_short_f = 6'd53;
+    io_i_short_s = 2'd3;
+    io_i_short_gen = 6'd53;
+    io_i_long_u = 2'd3;
+    io_i_long_f = 10'd845;
+    io_i_long_s = 2'd3;
+    io_i_long_gen = 10'd845;
+    io_i_b = 1'd1;
+    io_i_cGenL_real = 10'd845;
+    io_i_cGenL_imaginary = -845;
+    io_i_cFS_real = 6'd53;
+    io_i_cFS_imaginary = -53;
+    `expect("io_o_short_u",io_o_short_u,2,cycle)
+    `expect("io_o_short_u",io_o_short_u,2,cycle)
+    `expect("io_o_short_f",io_o_short_f,35,cycle)
+    `expect("io_o_short_f",io_o_short_f,35,cycle)
+    `expect("io_o_short_s",io_o_short_s,2,cycle)
+    `expect("io_o_short_s",io_o_short_s,2,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,35,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,35,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,563,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,-563,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,563,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,-563,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,35,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,-35,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,35,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,-35,cycle)
+    `expect("io_o_long_u",io_o_long_u,2,cycle)
+    `expect("io_o_long_u",io_o_long_u,2,cycle)
+    `expect("io_o_long_f",io_o_long_f,560,cycle)
+    `expect("io_o_long_f",io_o_long_f,560,cycle)
+    `expect("io_o_long_s",io_o_long_s,2,cycle)
+    `expect("io_o_long_s",io_o_long_s,2,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,560,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,560,cycle)
+    #(1*`CLK_PERIOD)     io_i_short_u = 2'd3;
+    io_i_short_f = -53;
+    io_i_short_s = -3;
+    io_i_short_gen = -53;
+    io_i_long_u = 2'd3;
+    io_i_long_f = -845;
+    io_i_long_s = -3;
+    io_i_long_gen = -845;
+    io_i_b = 1'd1;
+    io_i_cGenL_real = -845;
+    io_i_cGenL_imaginary = 10'd845;
+    io_i_cFS_real = -53;
+    io_i_cFS_imaginary = 6'd53;
+    `expect("io_o_short_u",io_o_short_u,3,cycle)
+    `expect("io_o_short_u",io_o_short_u,3,cycle)
+    `expect("io_o_short_f",io_o_short_f,52,cycle)
+    `expect("io_o_short_f",io_o_short_f,52,cycle)
+    `expect("io_o_short_s",io_o_short_s,3,cycle)
+    `expect("io_o_short_s",io_o_short_s,3,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,52,cycle)
+    `expect("io_o_short_gen",io_o_short_gen,52,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_b",io_o_b,1,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,845,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,-845,cycle)
+    `expect("io_o_cGenL_real",io_o_cGenL_real,845,cycle)
+    `expect("io_o_cGenL_imaginary",io_o_cGenL_imaginary,-845,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,53,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,-53,cycle)
+    `expect("io_o_cFS_real",io_o_cFS_real,53,cycle)
+    `expect("io_o_cFS_imaginary",io_o_cFS_imaginary,-53,cycle)
+    `expect("io_o_long_u",io_o_long_u,3,cycle)
+    `expect("io_o_long_u",io_o_long_u,3,cycle)
+    `expect("io_o_long_f",io_o_long_f,848,cycle)
+    `expect("io_o_long_f",io_o_long_f,848,cycle)
+    `expect("io_o_long_s",io_o_long_s,3,cycle)
+    `expect("io_o_long_s",io_o_long_s,3,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,848,cycle)
+    `expect("io_o_long_gen",io_o_long_gen,848,cycle)
+    #(1*`CLK_PERIOD)     io_i_vU_0 = 2'd3;
+    io_i_vS_0 = -3;
+    io_i_vF_0 = -53;
+    io_i_vU_1 = 2'd2;
+    io_i_vS_1 = -2;
+    io_i_vF_1 = -35;
+    io_i_vU_2 = 1'd1;
+    io_i_vS_2 = -1;
+    io_i_vF_2 = -18;
+    io_i_vU_3 = 1'd1;
+    io_i_vS_3 = -1;
+    io_i_vF_3 = -9;
+    io_i_vU_4 = 1'd0;
+    io_i_vS_4 = 1'd0;
+    io_i_vF_4 = -6;
+    io_i_vU_5 = 1'd0;
+    io_i_vS_5 = 1'd0;
+    io_i_vF_5 = 3'd6;
+    io_i_vU_6 = 1'd1;
+    io_i_vS_6 = 1'd1;
+    io_i_vF_6 = 4'd9;
+    io_i_vU_7 = 1'd1;
+    io_i_vS_7 = 1'd1;
+    io_i_vF_7 = 5'd18;
+    io_i_vU_8 = 2'd2;
+    io_i_vS_8 = 2'd2;
+    io_i_vF_8 = 6'd35;
+    io_i_vU_9 = 2'd3;
+    io_i_vS_9 = 2'd3;
+    io_i_vF_9 = 6'd53;
+    #(5*`CLK_PERIOD)     io_i_vU_0 = 2'd3;
+    io_i_vS_0 = 2'd3;
+    io_i_vF_0 = 6'd53;
+    `expect("io_o_vU_0",io_o_vU_0,3,cycle)
+    `expect("io_o_vU_0",io_o_vU_0,3,cycle)
+    `expect("io_o_vS_0",io_o_vS_0,-3,cycle)
+    `expect("io_o_vS_0",io_o_vS_0,-3,cycle)
+    `expect("io_o_vF_0",io_o_vF_0,-53,cycle)
+    `expect("io_o_vF_0",io_o_vF_0,-53,cycle)
+    io_i_vU_1 = 2'd2;
+    io_i_vS_1 = 2'd2;
+    io_i_vF_1 = 6'd35;
+    `expect("io_o_vU_1",io_o_vU_1,2,cycle)
+    `expect("io_o_vU_1",io_o_vU_1,2,cycle)
+    `expect("io_o_vS_1",io_o_vS_1,-2,cycle)
+    `expect("io_o_vS_1",io_o_vS_1,-2,cycle)
+    `expect("io_o_vF_1",io_o_vF_1,-35,cycle)
+    `expect("io_o_vF_1",io_o_vF_1,-35,cycle)
+    io_i_vU_2 = 1'd1;
+    io_i_vS_2 = 1'd1;
+    io_i_vF_2 = 5'd18;
+    `expect("io_o_vU_2",io_o_vU_2,1,cycle)
+    `expect("io_o_vU_2",io_o_vU_2,1,cycle)
+    `expect("io_o_vS_2",io_o_vS_2,-1,cycle)
+    `expect("io_o_vS_2",io_o_vS_2,-1,cycle)
+    `expect("io_o_vF_2",io_o_vF_2,-18,cycle)
+    `expect("io_o_vF_2",io_o_vF_2,-18,cycle)
+    io_i_vU_3 = 1'd1;
+    io_i_vS_3 = 1'd1;
+    io_i_vF_3 = 4'd9;
+    `expect("io_o_vU_3",io_o_vU_3,1,cycle)
+    `expect("io_o_vU_3",io_o_vU_3,1,cycle)
+    `expect("io_o_vS_3",io_o_vS_3,-1,cycle)
+    `expect("io_o_vS_3",io_o_vS_3,-1,cycle)
+    `expect("io_o_vF_3",io_o_vF_3,-9,cycle)
+    `expect("io_o_vF_3",io_o_vF_3,-9,cycle)
+    io_i_vU_4 = 1'd0;
+    io_i_vS_4 = 1'd0;
+    io_i_vF_4 = 3'd6;
+    `expect("io_o_vU_4",io_o_vU_4,0,cycle)
+    `expect("io_o_vU_4",io_o_vU_4,0,cycle)
+    `expect("io_o_vS_4",io_o_vS_4,0,cycle)
+    `expect("io_o_vS_4",io_o_vS_4,0,cycle)
+    `expect("io_o_vF_4",io_o_vF_4,-6,cycle)
+    `expect("io_o_vF_4",io_o_vF_4,-6,cycle)
+    io_i_vU_5 = 1'd0;
+    io_i_vS_5 = 1'd0;
+    io_i_vF_5 = -6;
+    `expect("io_o_vU_5",io_o_vU_5,0,cycle)
+    `expect("io_o_vU_5",io_o_vU_5,0,cycle)
+    `expect("io_o_vS_5",io_o_vS_5,0,cycle)
+    `expect("io_o_vS_5",io_o_vS_5,0,cycle)
+    `expect("io_o_vF_5",io_o_vF_5,6,cycle)
+    `expect("io_o_vF_5",io_o_vF_5,6,cycle)
+    io_i_vU_6 = 1'd1;
+    io_i_vS_6 = -1;
+    io_i_vF_6 = -9;
+    `expect("io_o_vU_6",io_o_vU_6,1,cycle)
+    `expect("io_o_vU_6",io_o_vU_6,1,cycle)
+    `expect("io_o_vS_6",io_o_vS_6,1,cycle)
+    `expect("io_o_vS_6",io_o_vS_6,1,cycle)
+    `expect("io_o_vF_6",io_o_vF_6,9,cycle)
+    `expect("io_o_vF_6",io_o_vF_6,9,cycle)
+    io_i_vU_7 = 1'd1;
+    io_i_vS_7 = -1;
+    io_i_vF_7 = -18;
+    `expect("io_o_vU_7",io_o_vU_7,1,cycle)
+    `expect("io_o_vU_7",io_o_vU_7,1,cycle)
+    `expect("io_o_vS_7",io_o_vS_7,1,cycle)
+    `expect("io_o_vS_7",io_o_vS_7,1,cycle)
+    `expect("io_o_vF_7",io_o_vF_7,18,cycle)
+    `expect("io_o_vF_7",io_o_vF_7,18,cycle)
+    io_i_vU_8 = 2'd2;
+    io_i_vS_8 = -2;
+    io_i_vF_8 = -35;
+    `expect("io_o_vU_8",io_o_vU_8,2,cycle)
+    `expect("io_o_vU_8",io_o_vU_8,2,cycle)
+    `expect("io_o_vS_8",io_o_vS_8,2,cycle)
+    `expect("io_o_vS_8",io_o_vS_8,2,cycle)
+    `expect("io_o_vF_8",io_o_vF_8,35,cycle)
+    `expect("io_o_vF_8",io_o_vF_8,35,cycle)
+    io_i_vU_9 = 2'd3;
+    io_i_vS_9 = -3;
+    io_i_vF_9 = -53;
+    `expect("io_o_vU_9",io_o_vU_9,3,cycle)
+    `expect("io_o_vU_9",io_o_vU_9,3,cycle)
+    `expect("io_o_vS_9",io_o_vS_9,3,cycle)
+    `expect("io_o_vS_9",io_o_vS_9,3,cycle)
+    `expect("io_o_vF_9",io_o_vF_9,53,cycle)
+    `expect("io_o_vF_9",io_o_vF_9,53,cycle)
+    #(5*`CLK_PERIOD)     io_i_vU_0 = 1'd0;
+    io_i_vS_0 = 1'd0;
+    io_i_vF_0 = 1'd0;
+    `expect("io_o_vU_0",io_o_vU_0,3,cycle)
+    `expect("io_o_vU_0",io_o_vU_0,3,cycle)
+    `expect("io_o_vS_0",io_o_vS_0,3,cycle)
+    `expect("io_o_vS_0",io_o_vS_0,3,cycle)
+    `expect("io_o_vF_0",io_o_vF_0,53,cycle)
+    `expect("io_o_vF_0",io_o_vF_0,53,cycle)
+    io_i_vU_1 = 1'd0;
+    io_i_vS_1 = 1'd0;
+    io_i_vF_1 = 1'd0;
+    `expect("io_o_vU_1",io_o_vU_1,2,cycle)
+    `expect("io_o_vU_1",io_o_vU_1,2,cycle)
+    `expect("io_o_vS_1",io_o_vS_1,2,cycle)
+    `expect("io_o_vS_1",io_o_vS_1,2,cycle)
+    `expect("io_o_vF_1",io_o_vF_1,35,cycle)
+    `expect("io_o_vF_1",io_o_vF_1,35,cycle)
+    io_i_vU_2 = 1'd0;
+    io_i_vS_2 = 1'd0;
+    io_i_vF_2 = 1'd0;
+    `expect("io_o_vU_2",io_o_vU_2,1,cycle)
+    `expect("io_o_vU_2",io_o_vU_2,1,cycle)
+    `expect("io_o_vS_2",io_o_vS_2,1,cycle)
+    `expect("io_o_vS_2",io_o_vS_2,1,cycle)
+    `expect("io_o_vF_2",io_o_vF_2,18,cycle)
+    `expect("io_o_vF_2",io_o_vF_2,18,cycle)
+    io_i_vU_3 = 1'd0;
+    io_i_vS_3 = 1'd0;
+    io_i_vF_3 = 1'd0;
+    `expect("io_o_vU_3",io_o_vU_3,1,cycle)
+    `expect("io_o_vU_3",io_o_vU_3,1,cycle)
+    `expect("io_o_vS_3",io_o_vS_3,1,cycle)
+    `expect("io_o_vS_3",io_o_vS_3,1,cycle)
+    `expect("io_o_vF_3",io_o_vF_3,9,cycle)
+    `expect("io_o_vF_3",io_o_vF_3,9,cycle)
+    io_i_vU_4 = 1'd0;
+    io_i_vS_4 = 1'd0;
+    io_i_vF_4 = 1'd0;
+    `expect("io_o_vU_4",io_o_vU_4,0,cycle)
+    `expect("io_o_vU_4",io_o_vU_4,0,cycle)
+    `expect("io_o_vS_4",io_o_vS_4,0,cycle)
+    `expect("io_o_vS_4",io_o_vS_4,0,cycle)
+    `expect("io_o_vF_4",io_o_vF_4,6,cycle)
+    `expect("io_o_vF_4",io_o_vF_4,6,cycle)
+    io_i_vU_5 = 1'd0;
+    io_i_vS_5 = 1'd0;
+    io_i_vF_5 = 1'd0;
+    `expect("io_o_vU_5",io_o_vU_5,0,cycle)
+    `expect("io_o_vU_5",io_o_vU_5,0,cycle)
+    `expect("io_o_vS_5",io_o_vS_5,0,cycle)
+    `expect("io_o_vS_5",io_o_vS_5,0,cycle)
+    `expect("io_o_vF_5",io_o_vF_5,-6,cycle)
+    `expect("io_o_vF_5",io_o_vF_5,-6,cycle)
+    io_i_vU_6 = 1'd0;
+    io_i_vS_6 = 1'd0;
+    io_i_vF_6 = 1'd0;
+    `expect("io_o_vU_6",io_o_vU_6,1,cycle)
+    `expect("io_o_vU_6",io_o_vU_6,1,cycle)
+    `expect("io_o_vS_6",io_o_vS_6,-1,cycle)
+    `expect("io_o_vS_6",io_o_vS_6,-1,cycle)
+    `expect("io_o_vF_6",io_o_vF_6,-9,cycle)
+    `expect("io_o_vF_6",io_o_vF_6,-9,cycle)
+    io_i_vU_7 = 1'd0;
+    io_i_vS_7 = 1'd0;
+    io_i_vF_7 = 1'd0;
+    `expect("io_o_vU_7",io_o_vU_7,1,cycle)
+    `expect("io_o_vU_7",io_o_vU_7,1,cycle)
+    `expect("io_o_vS_7",io_o_vS_7,-1,cycle)
+    `expect("io_o_vS_7",io_o_vS_7,-1,cycle)
+    `expect("io_o_vF_7",io_o_vF_7,-18,cycle)
+    `expect("io_o_vF_7",io_o_vF_7,-18,cycle)
+    io_i_vU_8 = 1'd0;
+    io_i_vS_8 = 1'd0;
+    io_i_vF_8 = 1'd0;
+    `expect("io_o_vU_8",io_o_vU_8,2,cycle)
+    `expect("io_o_vU_8",io_o_vU_8,2,cycle)
+    `expect("io_o_vS_8",io_o_vS_8,-2,cycle)
+    `expect("io_o_vS_8",io_o_vS_8,-2,cycle)
+    `expect("io_o_vF_8",io_o_vF_8,-35,cycle)
+    `expect("io_o_vF_8",io_o_vF_8,-35,cycle)
+    io_i_vU_9 = 1'd0;
+    io_i_vS_9 = 1'd0;
+    io_i_vF_9 = 1'd0;
+    `expect("io_o_vU_9",io_o_vU_9,3,cycle)
+    `expect("io_o_vU_9",io_o_vU_9,3,cycle)
+    `expect("io_o_vS_9",io_o_vS_9,-3,cycle)
+    `expect("io_o_vS_9",io_o_vS_9,-3,cycle)
+    `expect("io_o_vF_9",io_o_vF_9,-53,cycle)
+    `expect("io_o_vF_9",io_o_vF_9,-53,cycle)
+    `expect("io_o_vU_0",io_o_vU_0,3,cycle)
+    `expect("io_o_vU_1",io_o_vU_1,2,cycle)
+    `expect("io_o_vU_2",io_o_vU_2,1,cycle)
+    `expect("io_o_vU_3",io_o_vU_3,1,cycle)
+    `expect("io_o_vU_4",io_o_vU_4,0,cycle)
+    `expect("io_o_vU_5",io_o_vU_5,0,cycle)
+    `expect("io_o_vU_6",io_o_vU_6,1,cycle)
+    `expect("io_o_vU_7",io_o_vU_7,1,cycle)
+    `expect("io_o_vU_8",io_o_vU_8,2,cycle)
+    `expect("io_o_vU_9",io_o_vU_9,3,cycle)
+    `expect("io_o_vS_0",io_o_vS_0,3,cycle)
+    `expect("io_o_vS_1",io_o_vS_1,2,cycle)
+    `expect("io_o_vS_2",io_o_vS_2,1,cycle)
+    `expect("io_o_vS_3",io_o_vS_3,1,cycle)
+    `expect("io_o_vS_4",io_o_vS_4,0,cycle)
+    `expect("io_o_vS_5",io_o_vS_5,0,cycle)
+    `expect("io_o_vS_6",io_o_vS_6,-1,cycle)
+    `expect("io_o_vS_7",io_o_vS_7,-1,cycle)
+    `expect("io_o_vS_8",io_o_vS_8,-2,cycle)
+    `expect("io_o_vS_9",io_o_vS_9,-3,cycle)
+
+    #`CLK_PERIOD $display("\t **Ran through all test vectors**"); $finish;
+
+  end
+endmodule""".stripMargin
+}


### PR DESCRIPTION
@grebe I've tested a bunch of test bench use cases + the generated Verilog/TB files. It's kind of cool b/c I can simulate simple designs via https://www.edaplayground.com (Aldec Riviera Pro doesn't require verification...). I'll commit my tests to this branch, but as a final step, I compare the tb.v generated with a known working version... that also happens to be ~800 lines long. I'm going to commit that big tb too (I guess for more thorough regression tests?), but if you think it's too much, I can remove the commit and try a smaller tb... lmk what you prefer & then I'll squash + merge. 