### PR TITLE
Seamlessly move black box verilog implementations into target dir

### DIFF
--- a/src/main/scala/dsptools/numbers/DspReal.scala
+++ b/src/main/scala/dsptools/numbers/DspReal.scala
@@ -4,16 +4,22 @@ package dsptools.numbers
 
 import chisel3._
 import chisel3.core.Wire
+import chisel3.util.HasBlackBoxResource
 import dsptools.hasContext
 
-class BlackboxOneOperand extends BlackBox {
+trait BlackBoxWithVerilog extends BlackBox with HasBlackBoxResource {
+  def addVerilog(): Unit = {
+    setResource(DspReal.BlackBoxFloatVerilog)
+  }
+}
+class BlackboxOneOperand extends BlackBoxWithVerilog {
   val io = IO(new Bundle() {
     val in = Input(UInt(DspReal.UnderlyingWidth.W))
     val out = Output(UInt(DspReal.UnderlyingWidth.W))
   })
 }
 
-class BlackboxTwoOperand extends BlackBox {
+class BlackboxTwoOperand extends BlackBoxWithVerilog {
   val io = IO(new Bundle() {
     val in1 = Input(UInt(DspReal.UnderlyingWidth.W))
     val in2 = Input(UInt(DspReal.UnderlyingWidth.W))
@@ -21,7 +27,7 @@ class BlackboxTwoOperand extends BlackBox {
   })
 }
 
-class BlackboxTwoOperandBool extends BlackBox {
+class BlackboxTwoOperandBool extends BlackBoxWithVerilog {
   val io = IO(new Bundle() {
     val in1 = Input(UInt(DspReal.UnderlyingWidth.W))
     val in2 = Input(UInt(DspReal.UnderlyingWidth.W))
@@ -29,85 +35,88 @@ class BlackboxTwoOperandBool extends BlackBox {
   })
 }
 
-class BBFAdd extends BlackboxTwoOperand
+class BBFAdd extends BlackboxTwoOperand { addVerilog() }
 
-class BBFSubtract extends BlackboxTwoOperand
+class BBFSubtract extends BlackboxTwoOperand { addVerilog() }
 
-class BBFMultiply extends BlackboxTwoOperand
+class BBFMultiply extends BlackboxTwoOperand { addVerilog() }
 
-class BBFDivide extends BlackboxTwoOperand
+class BBFDivide extends BlackboxTwoOperand { addVerilog() }
 
-class BBFGreaterThan extends BlackboxTwoOperandBool
+class BBFGreaterThan extends BlackboxTwoOperandBool { addVerilog() }
 
-class BBFGreaterThanEquals extends BlackboxTwoOperandBool
+class BBFGreaterThanEquals extends BlackboxTwoOperandBool { addVerilog() }
 
-class BBFLessThan extends BlackboxTwoOperandBool
+class BBFLessThan extends BlackboxTwoOperandBool { addVerilog() }
 
-class BBFLessThanEquals extends BlackboxTwoOperandBool
+class BBFLessThanEquals extends BlackboxTwoOperandBool { addVerilog() }
 
-class BBFEquals extends BlackboxTwoOperandBool
+class BBFEquals extends BlackboxTwoOperandBool { addVerilog() }
 
-class BBFNotEquals extends BlackboxTwoOperandBool
+class BBFNotEquals extends BlackboxTwoOperandBool { addVerilog() }
 
 /** Math operations from IEEE.1364-2005 **/
-class BBFLn extends BlackboxOneOperand
+class BBFLn extends BlackboxOneOperand { addVerilog() }
 
-class BBFLog10 extends BlackboxOneOperand
+class BBFLog10 extends BlackboxOneOperand { addVerilog() }
 
-class BBFExp extends BlackboxOneOperand
+class BBFExp extends BlackboxOneOperand { addVerilog() }
 
-class BBFSqrt extends BlackboxOneOperand
+class BBFSqrt extends BlackboxOneOperand { addVerilog() }
 
-class BBFPow extends BlackboxTwoOperand
+class BBFPow extends BlackboxTwoOperand { addVerilog() }
 
-class BBFFloor extends BlackboxOneOperand
+class BBFFloor extends BlackboxOneOperand { addVerilog() }
 
-class BBFCeil extends BlackboxOneOperand
+class BBFCeil extends BlackboxOneOperand { addVerilog() }
 
-class BBFSin extends BlackboxOneOperand
+class BBFSin extends BlackboxOneOperand { addVerilog() }
 
-class BBFCos extends BlackboxOneOperand
+class BBFCos extends BlackboxOneOperand { addVerilog() }
 
-class BBFTan extends BlackboxOneOperand
+class BBFTan extends BlackboxOneOperand { addVerilog() }
 
-class BBFASin extends BlackboxOneOperand
+class BBFASin extends BlackboxOneOperand { addVerilog() }
 
-class BBFACos extends BlackboxOneOperand
+class BBFACos extends BlackboxOneOperand { addVerilog() }
 
-class BBFATan extends BlackboxOneOperand
+class BBFATan extends BlackboxOneOperand { addVerilog() }
 
-class BBFATan2 extends BlackboxTwoOperand
+class BBFATan2 extends BlackboxTwoOperand { addVerilog() }
 
-class BBFHypot extends BlackboxTwoOperand
+class BBFHypot extends BlackboxTwoOperand { addVerilog() }
 
-class BBFSinh extends BlackboxOneOperand
+class BBFSinh extends BlackboxOneOperand { addVerilog() }
 
-class BBFCosh extends BlackboxOneOperand
+class BBFCosh extends BlackboxOneOperand { addVerilog() }
 
-class BBFTanh extends BlackboxOneOperand
+class BBFTanh extends BlackboxOneOperand { addVerilog() }
 
-class BBFASinh extends BlackboxOneOperand
+class BBFASinh extends BlackboxOneOperand { addVerilog() }
 
-class BBFACosh extends BlackboxOneOperand
+class BBFACosh extends BlackboxOneOperand { addVerilog() }
 
-class BBFATanh extends BlackboxOneOperand
+class BBFATanh extends BlackboxOneOperand { addVerilog() }
 
-class BBFFromInt extends BlackBox {
+class BBFFromInt extends BlackBoxWithVerilog {
   val io = IO(new Bundle() {
     val in = Input(UInt(DspReal.UnderlyingWidth.W))
     val out = Output(UInt(DspReal.UnderlyingWidth.W))
   })
+  addVerilog()
 }
 
-class BBFToInt extends BlackBox {
+class BBFToInt extends BlackBoxWithVerilog {
   val io = IO(new Bundle() {
     val in = Input(UInt(DspReal.UnderlyingWidth.W))
     val out = Output(UInt(DspReal.UnderlyingWidth.W))
   })
+  addVerilog()
 }
 
-class BBFIntPart extends BlackboxOneOperand
+class BBFIntPart extends BlackboxOneOperand { addVerilog() }
 
+//scalastyle:off number.of.methods
 class DspReal(lit: Option[BigInt] = None) extends Bundle {
   val node: UInt = lit match {
     case Some(x) => x.U(DspReal.UnderlyingWidth.W)
@@ -310,6 +319,9 @@ object DspReal {
 
   // just the typ
   def apply(): DspReal = new DspReal()
+
+  val BlackBoxFloatVerilog = "/BlackBoxFloat.v"
+//  val BlackBoxFloatVerilog = "/BBFAdd.v"
 }
 
 trait DspRealRing extends Any with Ring[DspReal] with hasContext {

--- a/src/test/scala/dsptools/numbers/BlackBoxFloat.scala
+++ b/src/test/scala/dsptools/numbers/BlackBoxFloat.scala
@@ -1,23 +1,21 @@
-//// See LICENSE for license details.
+// See LICENSE for license details.
 
 package dsptools.numbers
 
-import java.nio.file.Files
-
 import chisel3._
-import chisel3.util._
+import chisel3.iotesters.{ChiselFlatSpec, TesterOptionsManager}
 import chisel3.testers.BasicTester
-import chisel3.iotesters.{ChiselFlatSpec, PeekPokeTester, TesterOptionsManager}
+import chisel3.util._
 import dsptools.DspTester
 
 //scalastyle:off magic.number regex
 
 class BlackBoxFloatTester extends BasicTester {
   val (cnt, _) = Counter(true.B, 10)
-  val accum = Reg(init=Wire(DspReal(1.0)))
+  val accum = RegInit(Wire(DspReal(1.0)))
 
-  val addOut = accum + DspReal(1.0)
-  val mulOut = addOut * DspReal(2.0)
+  private val addOut = accum + DspReal(1.0)
+  private val mulOut = addOut * DspReal(2.0)
 
   accum := addOut
 
@@ -256,20 +254,6 @@ class BlackBoxFloatSpec extends ChiselFlatSpec {
   "float ops" should "work with verilator" in {
     val optionsManager = new TesterOptionsManager {
         testerOptions = testerOptions.copy(backendName = "verilator")
-    }
-
-    //TODO: Fix this really ugly way of getting black box to verilator ASAP
-    optionsManager.setTargetDirName( "test_run_dir/floatops_verilator/")
-    optionsManager.setTopName("FloatOps")
-    optionsManager.makeTargetDir()
-
-    println(s"Dir is ${optionsManager.commonOptions.targetDirName}")
-    val blackBoxFile = new java.io.File("src/main/resources/BlackBoxFloat.v")
-    val resourceTarget = new java.io.File(optionsManager.targetDirName + "/" + "BBFAdd.v")
-    println(s"${blackBoxFile.getAbsolutePath} exists ${blackBoxFile.exists()}")
-    println(s"${resourceTarget.getAbsolutePath} exists ${resourceTarget.exists()}")
-    if(! resourceTarget.exists()) {
-      Files.copy(blackBoxFile.toPath, resourceTarget.toPath)
     }
 
     dsptools.Driver.execute(() => new FloatOpsWithoutTrig, optionsManager) { c =>


### PR DESCRIPTION
annotate black box modules to queue up their verilog implementation files into the directory where they will be picked up by verilog or vcs