### PR TITLE
Make DspComplex a Record.

### DIFF
--- a/src/test/scala/dsptools/numbers/TypeclassSpec.scala
+++ b/src/test/scala/dsptools/numbers/TypeclassSpec.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.iotesters._
 import dsptools.numbers._
 import dsptools.numbers.implicits._
-import org.scalatest.FreeSpec
+import org.scalatest._
 
 /*
  * These tests mostly exist to ensure that expressions of the form
@@ -69,35 +69,35 @@ class FuncTester[T <: FuncModule[SInt]](dut: T, inputs: Seq[Int], outputs: Seq[I
     }
 }
 
-class TypeclassSpec extends FreeSpec {
+class TypeclassSpec extends FreeSpec with Matchers {
   "Ring[T].func() should work" in {
     dsptools.Driver.execute( () => new RingModule(SInt(10.W)) ) { c =>
       new FuncTester(c, Seq(2, -3), Seq(2, -3))
-    }
+    } should be (true)
   }
   "Eq[T].func() should work" in {
     dsptools.Driver.execute( () => new EqModule(SInt(10.W)) ) { c =>
       new FuncTester(c, Seq(2, 0), Seq(2, 1))
-    }
+    } should be (true)
   }
   "Integer[T].func() should work" in {
     dsptools.Driver.execute( () => new RingModule(SInt(10.W)) ) { c =>
       new FuncTester(c, Seq(2, -3), Seq(3, -2))
-    }
+    } should be (true)
   }
   "Order[T].func() should work" in {
     dsptools.Driver.execute( () => new RingModule(SInt(10.W)) ) { c =>
       new FuncTester(c, Seq(2, -3), Seq(2, -3))
-    }
+    } should be (true)
   }
   "PartialOrder[T].func() should work" in {
     dsptools.Driver.execute( () => new RingModule(SInt(10.W)) ) { c =>
       new FuncTester(c, Seq(2, -3), Seq(2, -3))
-    }
+    } should be (true)
   }
   "Signed[T].func() should work" in {
     dsptools.Driver.execute( () => new RingModule(SInt(10.W)) ) { c =>
       new FuncTester(c, Seq(2, -3), Seq(2, 3))
-    }
+    } should be (true)
   }
 }


### PR DESCRIPTION
Also, fix tests that were failing quietly.

@shunshou I'm working on getting everything building against the add_ops branch. So far not too many problems, but we had several instances of `imaginary` being called without () which is a compilation error as long as `dummy` is being used.

I took it as an opportunity to try the new `Record` thing out and it seems to be pretty simple. Unfortunately, some tests are failing, but they don't seem to be related to Record. Do these tests fail for you, or is it somehow b/c of my changes?

Some tests were failing quietly so I added should be (true) in some places.

Also note that I have a small PR against chisel-testers to get Record working with PeekPokeTester

Also, I haven't done so here, but I feel like I should deprecate `imaginary` to remind us to move everything over to `imag`. What do you think?