### PR TITLE
Temp resolution to Ring ops without using Gen

### DIFF
--- a/src/main/scala/dsptools/numbers/README.md
+++ b/src/main/scala/dsptools/numbers/README.md
@@ -3,6 +3,15 @@
 > If you want to support IsIntegral operations for SInt + UInt (in addition to the others), you want a: T where `[T <: Data:IntegerBits]`
 > DspReal is *not* synthesizable!
 
+BIG WARNING: If you want to directly use UInt, SInt, & FixedPoint without passing them through some generic, you **should not** use the Ring operators +, -, *, unary_- *if* you want to use DspContext. Using + on a normal UInt will result in Chisel + behavior (wrapped addition). To guarantee that the Ring operators follow DspContext, after importing implicits, you should instead use:
+* a context_+ b
+* a context_- b
+* a context_* b
+* a.context_unary_- 
+
+We need to come up with better names, but at least this makes it easy to search for context_...
+
+
 # DspContext
 * DspContext allows you to change how certain operations behave via a dynamic variable
 * The DspContext case class contains the following fields:

--- a/src/main/scala/dsptools/numbers/implicits/AllOps.scala
+++ b/src/main/scala/dsptools/numbers/implicits/AllOps.scala
@@ -120,3 +120,10 @@ class BinaryRepresentationOps[A <: Data](lhs: A)(implicit ev: BinaryRepresentati
   def mul2(n: Int): A = ev.mul2(lhs, n)
   def trimBinary(n: Int): A = ev.trimBinary(lhs, n)
 }
+
+class ContextualRingOps[A <: Data](lhs: A)(implicit ev: Ring[A]) {
+  def context_+(rhs: A): A = ev.plus(lhs, rhs)
+  def context_-(rhs: A): A = ev.minus(lhs, rhs)
+  def context_*(rhs: A): A = ev.times(lhs, rhs)
+  def context_unary_-(): A = ev.negate(lhs)
+}

--- a/src/main/scala/dsptools/numbers/implicits/ImplicitSyntax.scala
+++ b/src/main/scala/dsptools/numbers/implicits/ImplicitSyntax.scala
@@ -41,3 +41,7 @@ trait ChiselConvertableFromSyntax {
 trait BinaryRepresentationSyntax {
   implicit def binaryRepresentationOps[A <: Data:BinaryRepresentation](a: A): BinaryRepresentationOps[A] = new BinaryRepresentationOps(a)
 }
+
+trait ContextualRingSyntax {
+  implicit def contextualRingOps[A <: Data:Ring](a: A): ContextualRingOps[A] = new ContextualRingOps(a)
+}

--- a/src/main/scala/dsptools/numbers/implicits/ImplicitsTop.scala
+++ b/src/main/scala/dsptools/numbers/implicits/ImplicitsTop.scala
@@ -5,7 +5,7 @@ package dsptools.numbers
 import chisel3.experimental.FixedPoint
 
 trait AllSyntax extends EqSyntax with PartialOrderSyntax with OrderSyntax with SignedSyntax with IsRealSyntax with IsIntegerSyntax with
-  ConvertableToSyntax with ChiselConvertableFromSyntax with BinaryRepresentationSyntax
+  ConvertableToSyntax with ChiselConvertableFromSyntax with BinaryRepresentationSyntax with ContextualRingSyntax
 
 trait AllImpl extends UIntImpl with SIntImpl with FixedPointImpl with DspRealImpl with DspComplexImpl
 


### PR DESCRIPTION
So that you still get DspContext. Must use context_+, etc. Maybe different names are better... This still has issues b/c you're not preventing people from using +, so they could still think + gets DspContext when it doesn't...