### PR TITLE
Update from release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,38 @@
 // See LICENSE for license details.
 
+def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // If we're building with Scala > 2.11, enable the compile option
+    //  switch to support our anonymous Bundle definitions:
+    //  https://github.com/scala/bug/issues/10047
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor: Int)) if scalaMajor < 12 => Seq()
+      case _ => Seq("-Xsource:2.11")
+    }
+  }
+}
+
+def javacOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // Scala 2.12 requires Java 8. We continue to generate
+    //  Java 7 compatible code for Scala 2.11
+    //  for compatibility with old clients.
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor: Int)) if scalaMajor < 12 =>
+        Seq("-source", "1.7", "-target", "1.7")
+      case _ =>
+        Seq("-source", "1.8", "-target", "1.8")
+    }
+  }
+}
+
 name := "dsptools"
 
 organization := "edu.berkeley.cs"
 
 version := "1.1-SNAPSHOT"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.11"
 
 resolvers ++= Seq (
   Resolver.sonatypeRepo("snapshots"),
@@ -17,12 +43,12 @@ libraryDependencies ++= Seq("chisel3","chisel-iotesters").map {
   dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
 }
 
-scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:reflectiveCalls")
+scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:reflectiveCalls") ++ scalacOptionsVersion(scalaVersion.value)
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "chisel3" -> "3.0-SNAPSHOT_2017-08-16",
-  "chisel-iotesters" -> "1.1-SNAPSHOT_2017-08-16"
+  "chisel3" -> "3.0-SNAPSHOT",
+  "chisel-iotesters" -> "1.1-SNAPSHOT"
 )
 
 libraryDependencies ++= Seq(
@@ -32,3 +58,51 @@ libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck" % "1.13.4",
   "co.theasi" %% "plotly" % "0.1"
 )
+
+javacOptions ++= javacOptionsVersion(scalaVersion.value)
+    
+publishMavenStyle := true
+
+publishArtifact in Test := false
+pomIncludeRepository := { x => false }
+
+pomExtra := (<url>http://chisel.eecs.berkeley.edu/</url>
+<licenses>
+  <license>
+    <name>BSD-style</name>
+    <url>http://www.opensource.org/licenses/bsd-license.php</url>
+    <distribution>repo</distribution>
+  </license>
+</licenses>
+<scm>
+  <url>https://github.com/ucb-bar/dsptools.git</url>
+  <connection>scm:git:github.com/ucb-bar/dsptools.git</connection>
+</scm>
+<developers>
+  <developer>
+    <id>grebe</id>
+    <name>Paul Rigge</name>
+    <url>http://www.eecs.berkeley.edu/~rigge/</url>
+  </developer>
+  <developer>
+    <id>shunshou</id>
+    <name>Angie Wang</name>
+    <url>https://www.linkedin.com/in/angie-wang-ee/</url>
+  </developer>
+  <developer>
+    <id>chick</id>
+    <name>Charles Markley</name>
+    <url>https://aspire.eecs.berkeley.edu/author/chick/</url>
+  </developer>
+ </developers>)
+
+publishTo := {
+  val v = version.value
+  val nexus = "https://oss.sonatype.org/"
+  if (v.trim.endsWith("SNAPSHOT")) {
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  }
+  else {
+    Some("releases" at nexus + "service/local/staging/deploy/maven2")
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")


### PR DESCRIPTION
Add publishing parameters from release (so they're available for editing in master).
Bump Scala version to 2.11.11
Use "current" published SNAPSHOT versions of Chisel dependencies.