### PR TITLE
Enable DspReal constants and initialize test hardware in preparation for the InvalidateAPI.

### DIFF
--- a/src/main/scala/dsptools/numbers/chisel_concrete/DspReal.scala
+++ b/src/main/scala/dsptools/numbers/chisel_concrete/DspReal.scala
@@ -346,14 +346,19 @@ class DspReal(lit: Option[BigInt] = None) extends Bundle {
 
 object DspReal {
   val underlyingWidth = 64
-  
+  private val zero = DspReal(0.0, false)
+
   /** Creates a Real with a constant value.
     */
-  def apply(value: Double): DspReal = {
+  def apply(value: Double, addZero: Boolean = true): DspReal = {
     // See http://stackoverflow.com/questions/21212993/unsigned-variables-in-scala
     def longAsUnsignedBigInt(in: Long): BigInt = (BigInt(in >>> 1) << 1) + (in & 1)
     def doubleToBigInt(in: Double): BigInt = longAsUnsignedBigInt(java.lang.Double.doubleToRawLongBits(in))
-    new DspReal(Some(doubleToBigInt(value)))
+    if (addZero) {
+      new DspReal(Some(doubleToBigInt(value))) + zero
+    } else {
+      new DspReal(Some(doubleToBigInt(value)))
+    }
   }
 
   /**

--- a/src/test/scala/dsptools/numbers/BlackBoxFloat.scala
+++ b/src/test/scala/dsptools/numbers/BlackBoxFloat.scala
@@ -12,7 +12,7 @@ import dsptools.DspTester
 
 class BlackBoxFloatTester extends BasicTester {
   val (cnt, _) = Counter(true.B, 10)
-  val accum = RegInit(Wire(DspReal(1.0)))
+  val accum = RegInit(DspReal(0))
 
   private val addOut = accum + DspReal(1.0)
   private val mulOut = addOut * DspReal(2.0)
@@ -105,6 +105,9 @@ class FloatOps extends Module {
     val out = Output(DspReal(1.0))
     val boolOut = Output(Bool())
   })
+
+  io.boolOut := false.B
+  io.out := DspReal(0)
 }
 
 class FloatOpsWithTrig extends FloatOps {

--- a/src/test/scala/dsptools/numbers/FixedPointSpec.scala
+++ b/src/test/scala/dsptools/numbers/FixedPointSpec.scala
@@ -24,6 +24,7 @@ class FixedRing1(val width: Int, val binaryPoint: Int) extends Module {
   io.ceil := io.in.ceil()
   io.isWhole := io.in.isWhole()
   io.round := io.in.round()
+  io.real := DspReal(0)
 }
 
 class FixedRing1Tester(c: FixedRing1) extends DspTester(c) {


### PR DESCRIPTION
Use the internal arithmetic classes to enable DspReal literals.
Add an optional argument to DspReal class constructor (to avoid recursion) when using the above to create literals.