### PR TITLE
Clone fix - don't use literals where pure types are expected.

### DIFF
--- a/src/test/scala/dsptools/numbers/BlackBoxFloat.scala
+++ b/src/test/scala/dsptools/numbers/BlackBoxFloat.scala
@@ -44,11 +44,11 @@ class BlackBoxFloatTester extends BasicTester {
 
 class BlackBoxFloatAdder extends Module {
   val io = IO(new Bundle {
-    val a = Input(DspReal(1.0))
-    val b = Input(DspReal(1.0))
-    val c = Output(DspReal(1.0))
-    val d = Output(DspReal(1.0))
-    val e = Output(DspReal(1.0))
+    val a = Input(DspReal())
+    val b = Input(DspReal())
+    val c = Output(DspReal())
+    val d = Output(DspReal())
+    val e = Output(DspReal())
   })
 
   io.c := io.a + io.b
@@ -99,10 +99,10 @@ object FloatOpCodes {
 
 class FloatOps extends Module {
   val io = IO(new Bundle {
-    val in1 = Input(DspReal(1.0))
-    val in2 = Input(DspReal(1.0))
+    val in1 = Input(DspReal())
+    val in2 = Input(DspReal())
     val opsel = Input(UInt(64.W))
-    val out = Output(DspReal(1.0))
+    val out = Output(DspReal())
     val boolOut = Output(Bool())
   })
 

--- a/src/test/scala/dsptools/numbers/FixedPointSpec.scala
+++ b/src/test/scala/dsptools/numbers/FixedPointSpec.scala
@@ -17,7 +17,7 @@ class FixedRing1(val width: Int, val binaryPoint: Int) extends Module {
     val ceil = Output(FixedPoint(width.W, binaryPoint.BP))
     val isWhole = Output(Bool())
     val round = Output(FixedPoint(width.W, binaryPoint.BP))
-    val real = Output(DspReal(1.0))
+    val real = Output(DspReal())
   })
 
   io.floor := io.in.floor()

--- a/src/test/scala/dsptools/numbers/LnSpec.scala
+++ b/src/test/scala/dsptools/numbers/LnSpec.scala
@@ -11,8 +11,8 @@ import org.scalatest.FreeSpec
 
 class LnModule extends Module {
   val io = IO(new Bundle {
-    val num = Input(DspReal(1.0))
-    val ln = Output(DspReal(1.0))
+    val num = Input(DspReal())
+    val ln = Output(DspReal())
   })
 
   io.ln := io.num.ln()


### PR DESCRIPTION
Now that Chisel complains if it sees hardware where a pure type is expected, and DspReal literals work, fix cases where a literal was used in place of a pure type.