### PR TITLE
Make lit parameter to DspReal constructor a val to avoid upsetting autoclonetype.

### DIFF
--- a/src/main/scala/dsptools/numbers/chisel_concrete/DspReal.scala
+++ b/src/main/scala/dsptools/numbers/chisel_concrete/DspReal.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.util.Mux1H
 
 //scalastyle:off number.of.methods
-class DspReal(lit: Option[BigInt] = None) extends Bundle {
+class DspReal(val lit: Option[BigInt] = None) extends Bundle {
   
   val node: UInt = lit match {
     case Some(x) => x.U(DspReal.underlyingWidth.W)


### PR DESCRIPTION
autoclonetype will complain if it needs to clone an object with mutable parameters as this can lead to hard to diagnose bugs.
