### PR TITLE
Bump sbt to 1.0.4 and update plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,18 @@
 // See LICENSE for license details.
 
+enablePlugins(SiteScaladocPlugin)
+
+enablePlugins(GhpagesPlugin)
+
+git.remoteRepo := "git@github.com:ucb-bar/dsptools.git"
+
 def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
   Seq() ++ {
     // If we're building with Scala > 2.11, enable the compile option
     //  switch to support our anonymous Bundle definitions:
     //  https://github.com/scala/bug/issues/10047
     CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Int)) if scalaMajor < 12 => Seq()
+      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
       case _ => Seq("-Xsource:2.11")
     }
   }
@@ -18,7 +24,7 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
     //  Java 7 compatible code for Scala 2.11
     //  for compatibility with old clients.
     CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Int)) if scalaMajor < 12 =>
+      case Some((2, scalaMajor: Long)) if scalaMajor < 12 =>
         Seq("-source", "1.7", "-target", "1.7")
       case _ =>
         Seq("-source", "1.8", "-target", "1.8")
@@ -32,9 +38,9 @@ organization := "edu.berkeley.cs"
 
 version := "1.1-SNAPSHOT"
 
-scalaVersion := "2.11.11"
+scalaVersion := "2.11.12"
 
-crossScalaVersions := Seq("2.11.11", "2.12.3")
+crossScalaVersions := Seq("2.11.12", "2.12.4")
 
 resolvers ++= Seq (
   Resolver.sonatypeRepo("snapshots"),
@@ -67,6 +73,7 @@ publishMavenStyle := true
 publishArtifact in Test := false
 pomIncludeRepository := { x => false }
 
+// Don't add 'scm' elements if we have a git.remoteRepo definition.
 pomExtra := (<url>http://chisel.eecs.berkeley.edu/</url>
 <licenses>
   <license>
@@ -75,10 +82,6 @@ pomExtra := (<url>http://chisel.eecs.berkeley.edu/</url>
     <distribution>repo</distribution>
   </license>
 </licenses>
-<scm>
-  <url>https://github.com/ucb-bar/dsptools.git</url>
-  <connection>scm:git:github.com/ucb-bar/dsptools.git</connection>
-</scm>
 <developers>
   <developer>
     <id>grebe</id>

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,8 @@ version := "1.1-SNAPSHOT"
 
 scalaVersion := "2.11.11"
 
+crossScalaVersions := Seq("2.11.11", "2.12.3")
+
 resolvers ++= Seq (
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases")

--- a/build.sbt
+++ b/build.sbt
@@ -55,8 +55,8 @@ scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:refle
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "chisel3" -> "3.0-SNAPSHOT",
-  "chisel-iotesters" -> "1.1-SNAPSHOT"
+  "chisel3" -> "3.1-SNAPSHOT",
+  "chisel-iotesters" -> "1.2-SNAPSHOT"
 )
 
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,11 @@
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.1")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")
+


### PR DESCRIPTION
**NOTE** This PR also changes the library dependencies to the SNAPSHOT versions of the associated master branches (as with all current BIG5 branches), and therefor assumes the client has performed a `publishLocal` on those branches.

Release branches will continue to use the release versions of associated BIG5 projects.
