### PR TITLE
Add treadle hooks for DspReals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
     INSTALL_DIR=$TRAVIS_BUILD_DIR/install
     VERILATOR_ROOT=$INSTALL_DIR
     PATH=$PATH:$VERILATOR_ROOT/bin:$TRAVIS_BUILD_DIR/utils/bin
-    CHISEL3=3.1.0
-    CHISEL_TESTERS=1.2.0
+    CHISEL3=3.1.2
+    CHISEL_TESTERS=1.2.3
 
 install:
   # Install dependencies

--- a/src/main/scala/dsptools/Driver.scala
+++ b/src/main/scala/dsptools/Driver.scala
@@ -4,9 +4,10 @@ package dsptools
 
 import chisel3._
 import chisel3.iotesters._
-import firrtl.{HasFirrtlOptions, ExecutionOptionsManager}
-import numbers.DspRealFactory
+import firrtl.{ExecutionOptionsManager, HasFirrtlOptions}
+import numbers.{DspRealFactory, TreadleDspRealFactory}
 import firrtl_interpreter._
+import treadle.HasTreadleOptions
 
 import scala.util.DynamicVariable
 
@@ -21,11 +22,15 @@ object Driver {
     val om = optionsManager match {
       case d: DspTesterOptionsManager => Some(d)
       case _ => None
-    }                       
+    }
 
-    optionsManagerVar.withValue(om) {                          
+    optionsManagerVar.withValue(om) {
       optionsManager.interpreterOptions = optionsManager.interpreterOptions.copy(
-          blackBoxFactories = optionsManager.interpreterOptions.blackBoxFactories :+ new DspRealFactory)
+          blackBoxFactories = optionsManager.interpreterOptions.blackBoxFactories :+ new DspRealFactory
+      )
+      optionsManager.treadleOptions = optionsManager.treadleOptions.copy(
+        blackBoxFactories = optionsManager.treadleOptions.blackBoxFactories :+ new TreadleDspRealFactory
+      )
       iotesters.Driver.execute(dutGenerator, optionsManager)(testerGen)
     }
 
@@ -36,7 +41,11 @@ object Driver {
 
     val optionsManager = new DspTesterOptionsManager {
       interpreterOptions = interpreterOptions.copy(
-          blackBoxFactories = interpreterOptions.blackBoxFactories :+ new DspRealFactory)
+          blackBoxFactories = interpreterOptions.blackBoxFactories :+ new DspRealFactory
+      )
+      treadleOptions = treadleOptions.copy(
+        blackBoxFactories = treadleOptions.blackBoxFactories :+ new TreadleDspRealFactory
+      )
     }
 
     if (optionsManager.parse(args)) execute(dutGenerator, optionsManager)(testerGen)
@@ -52,7 +61,11 @@ object Driver {
     optionsManager.chiselOptions = optionsManager.chiselOptions.copy(runFirrtlCompiler = false)
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(compilerName = "low")
     optionsManager.interpreterOptions = optionsManager.interpreterOptions.copy(
-        blackBoxFactories = optionsManager.interpreterOptions.blackBoxFactories :+ new DspRealFactory)
+        blackBoxFactories = optionsManager.interpreterOptions.blackBoxFactories :+ new DspRealFactory
+    )
+    optionsManager.treadleOptions = optionsManager.treadleOptions.copy(
+      blackBoxFactories = optionsManager.treadleOptions.blackBoxFactories :+ new TreadleDspRealFactory
+    )
 
     logger.Logger.makeScope(optionsManager) {
       val chiselResult: ChiselExecutionResult = chisel3.Driver.execute(optionsManager, dutGenerator)
@@ -76,3 +89,4 @@ class ReplOptionsManager
     with HasChiselExecutionOptions
     with HasFirrtlOptions
     with HasReplConfig
+    with HasTreadleOptions

--- a/src/main/scala/dsptools/numbers/blackbox_compatibility/DspRealFirrtlInterpBB.scala
+++ b/src/main/scala/dsptools/numbers/blackbox_compatibility/DspRealFirrtlInterpBB.scala
@@ -4,9 +4,11 @@ package dsptools.numbers
 
 import firrtl.ir.Type
 import firrtl_interpreter._
+import treadle.{ScalaBlackBox, ScalaBlackBoxFactory}
 
+trait DspBlackBlackBoxImpl extends BlackBoxImplementation with ScalaBlackBox
 
-abstract class DspRealTwoArgumentToDouble extends BlackBoxImplementation {
+abstract class DspRealTwoArgumentToDouble extends DspBlackBlackBoxImpl {
   /**
     * sub-classes must implement this two argument function
     *
@@ -22,7 +24,17 @@ abstract class DspRealTwoArgumentToDouble extends BlackBoxImplementation {
       case _ => Seq.empty
     }
   }
+
+  override def getOutput(inputValues: Seq[BigInt], tpe: Type, outputName: String): BigInt = {
+    val arg1 :: arg2 :: _ = inputValues
+    val doubleArg1 = bigIntBitsToDouble(arg1)
+    val doubleArg2 = bigIntBitsToDouble(arg2)
+    val doubleResult = twoOp(doubleArg1, doubleArg2)
+    doubleToBigIntBits(doubleResult)
+  }
+
   def cycle(): Unit = {}
+
   def execute(inputValues: Seq[Concrete], tpe: Type, outputName: String): Concrete = {
     val arg1 :: arg2 :: _ = inputValues
     val doubleArg1 = bigIntBitsToDouble(arg1.value)
@@ -33,7 +45,7 @@ abstract class DspRealTwoArgumentToDouble extends BlackBoxImplementation {
   }
 }
 
-abstract class DspRealOneArgumentToDouble extends BlackBoxImplementation {
+abstract class DspRealOneArgumentToDouble extends DspBlackBlackBoxImpl {
   /**
     * sub-classes must implement this two argument function
     *
@@ -49,6 +61,7 @@ abstract class DspRealOneArgumentToDouble extends BlackBoxImplementation {
     }
   }
   def cycle(): Unit = {}
+
   def execute(inputValues: Seq[Concrete], tpe: Type, outputName: String): Concrete = {
     val arg1 :: _ = inputValues
     val doubleArg1 = bigIntBitsToDouble(arg1.value)
@@ -56,9 +69,16 @@ abstract class DspRealOneArgumentToDouble extends BlackBoxImplementation {
     val result = doubleToBigIntBits(doubleResult)
     ConcreteSInt(result, DspReal.underlyingWidth, arg1.poisoned).asUInt
   }
+
+  def getOutput(inputValues: Seq[BigInt], tpe: Type, outputName: String): BigInt = {
+    val arg1 :: _ = inputValues
+    val doubleArg1 = bigIntBitsToDouble(arg1)
+    val doubleResult = oneOp(doubleArg1)
+    doubleToBigIntBits(doubleResult)
+  }
 }
 
-abstract class DspRealTwoArgumentToBoolean extends BlackBoxImplementation {
+abstract class DspRealTwoArgumentToBoolean extends DspBlackBlackBoxImpl {
   /**
     * sub-classes must implement this two argument function
     *
@@ -75,6 +95,15 @@ abstract class DspRealTwoArgumentToBoolean extends BlackBoxImplementation {
     }
   }
   def cycle(): Unit = {}
+
+  def getOutput(inputValues: Seq[BigInt], tpe: Type, outputName: String): BigInt = {
+    val arg1 :: arg2 :: _ = inputValues
+    val doubleArg1 = bigIntBitsToDouble(arg1)
+    val doubleArg2 = bigIntBitsToDouble(arg2)
+    val booleanResult = twoOp(doubleArg1, doubleArg2)
+    if (booleanResult) Big1 else Big0
+  }
+
   def execute(inputValues: Seq[Concrete], tpe: Type, outputName: String): Concrete = {
     val arg1 :: arg2 :: _ = inputValues
     val doubleArg1 = bigIntBitsToDouble(arg1.value)
@@ -217,7 +246,7 @@ class DspRealATanh(val name: String)  extends DspRealOneArgumentToDouble {
   def oneOp(double1: Double): Double = 0.5 * math.log((1 + double1) / (1 - double1))
 }
 
-class DspRealToInt(val name: String) extends BlackBoxImplementation {
+class DspRealToInt(val name: String) extends DspBlackBlackBoxImpl {
   def outputDependencies(outputName: String): Seq[(String)] = {
     outputName match {
       case "out" => Seq("in")
@@ -225,14 +254,20 @@ class DspRealToInt(val name: String) extends BlackBoxImplementation {
     }
   }
   def cycle(): Unit = {}
+
   def execute(inputValues: Seq[Concrete], tpe: Type, outputName: String): Concrete = {
     val arg1 :: _ = inputValues
     val result = arg1.value
     TypeInstanceFactory(tpe, result)
   }
+
+  def getOutput(inputValues: Seq[BigInt], tpe: Type, outputName: String): BigInt = {
+    val arg1 :: _ = inputValues
+    arg1
+  }
 }
 
-class DspRealFromInt(val name: String) extends BlackBoxImplementation {
+class DspRealFromInt(val name: String) extends DspBlackBlackBoxImpl {
   def outputDependencies(outputName: String): Seq[(String)] = {
     outputName match {
       case "out" => Seq("in")
@@ -240,6 +275,12 @@ class DspRealFromInt(val name: String) extends BlackBoxImplementation {
     }
   }
   def cycle(): Unit = {}
+
+  def getOutput(inputValues: Seq[BigInt], tpe: Type, outputName: String): BigInt = {
+    val arg1 :: _ = inputValues
+    arg1
+  }
+
   def execute(inputValues: Seq[Concrete], tpe: Type, outputName: String): Concrete = {
     val arg1 :: _ = inputValues
     val result = arg1.value
@@ -247,8 +288,51 @@ class DspRealFromInt(val name: String) extends BlackBoxImplementation {
   }
 }
 
+//scalastyle:off cyclomatic.complexity
 class DspRealFactory extends BlackBoxFactory {
   def createInstance(instanceName: String, blackBoxName: String): Option[BlackBoxImplementation] = {
+    blackBoxName match {
+      case "BBFAdd"               => Some(add(new DspRealAdd(instanceName)))
+      case "BBFSubtract"          => Some(add(new DspRealSubtract(instanceName)))
+      case "BBFMultiply"          => Some(add(new DspRealMultiply(instanceName)))
+      case "BBFDivide"            => Some(add(new DspRealDivide(instanceName)))
+      case "BBFLessThan"          => Some(add(new DspRealLessThan(instanceName)))
+      case "BBFLessThanEquals"    => Some(add(new DspRealLessThanEquals(instanceName)))
+      case "BBFGreaterThan"       => Some(add(new DspRealGreaterThan(instanceName)))
+      case "BBFGreaterThanEquals" => Some(add(new DspRealGreaterThanEquals(instanceName)))
+      case "BBFEquals"            => Some(add(new DspRealEquals(instanceName)))
+      case "BBFNotEquals"         => Some(add(new DspRealNotEquals(instanceName)))
+      case "BBFFromInt"           => Some(add(new DspRealFromInt(instanceName)))
+      case "BBFToInt"             => Some(add(new DspRealToInt(instanceName)))
+      //case "BBFIntPart"           => Some(add(new DspRealIntPart(instanceName)))
+      case "BBFLn"                => Some(add(new DspRealLn(instanceName)))
+      case "BBFLog10"             => Some(add(new DspRealLog10(instanceName)))
+      case "BBFExp"               => Some(add(new DspRealExp(instanceName)))
+      case "BBFSqrt"              => Some(add(new DspRealSqrt(instanceName)))
+      case "BBFPow"               => Some(add(new DspRealPow(instanceName)))
+      case "BBFFloor"             => Some(add(new DspRealFloor(instanceName)))
+      case "BBFCeil"              => Some(add(new DspRealCeil(instanceName)))
+      case "BBFSin"               => Some(add(new DspRealSin(instanceName)))
+      case "BBFCos"               => Some(add(new DspRealCos(instanceName)))
+      case "BBFTan"               => Some(add(new DspRealTan(instanceName)))
+      case "BBFASin"              => Some(add(new DspRealASin(instanceName)))
+      case "BBFACos"              => Some(add(new DspRealACos(instanceName)))
+      case "BBFATan"              => Some(add(new DspRealATan(instanceName)))
+      case "BBFATan2"             => Some(add(new DspRealATan2(instanceName)))
+      case "BBFHypot"             => Some(add(new DspRealHypot(instanceName)))
+      case "BBFSinh"              => Some(add(new DspRealSinh(instanceName)))
+      case "BBFCosh"              => Some(add(new DspRealCosh(instanceName)))
+      case "BBFTanh"              => Some(add(new DspRealTanh(instanceName)))
+      case "BBFASinh"             => Some(add(new DspRealASinh(instanceName)))
+      case "BBFACosh"             => Some(add(new DspRealACosh(instanceName)))
+      case "BBFATanh"             => Some(add(new DspRealATanh(instanceName)))
+      case _                      => None
+    }
+  }
+}
+
+class TreadleDspRealFactory extends ScalaBlackBoxFactory {
+  def createInstance(instanceName: String, blackBoxName: String): Option[ScalaBlackBox] = {
     blackBoxName match {
       case "BBFAdd"               => Some(add(new DspRealAdd(instanceName)))
       case "BBFSubtract"          => Some(add(new DspRealSubtract(instanceName)))

--- a/src/test/scala/dsptools/numbers/BlackBoxFloat.scala
+++ b/src/test/scala/dsptools/numbers/BlackBoxFloat.scala
@@ -251,12 +251,7 @@ class FloatOpTester[T <: FloatOps](c: T, testTrigFuncs: Boolean = true) extends 
 
 class BlackBoxFloatSpec extends ChiselFlatSpec {
   "A BlackBoxed FP block" should "work" in {
-    assertTesterPasses({ new BlackBoxFloatTester },
-        Seq(
-          "/BBFAdd.v",
-          "/BBFMultiply.v",
-          "/BBFEquals.v"
-          ))
+    assertTesterPasses({ new BlackBoxFloatTester })
   }
 
   "basic addition" should "work with reals through black boxes" in {

--- a/src/test/scala/dsptools/numbers/BlackBoxFloat.scala
+++ b/src/test/scala/dsptools/numbers/BlackBoxFloat.scala
@@ -251,7 +251,13 @@ class FloatOpTester[T <: FloatOps](c: T, testTrigFuncs: Boolean = true) extends 
 
 class BlackBoxFloatSpec extends ChiselFlatSpec {
   "A BlackBoxed FP block" should "work" in {
-    assertTesterPasses({ new BlackBoxFloatTester })
+    assertTesterPasses({ new BlackBoxFloatTester }
+      , Seq(
+      "/BBFAdd.v",
+      "/BBFMultiply.v",
+      "/BBFEquals.v"
+      )
+    )
   }
 
   "basic addition" should "work with reals through black boxes" in {

--- a/src/test/scala/examples/ComplexAdderSpec.scala
+++ b/src/test/scala/examples/ComplexAdderSpec.scala
@@ -1,5 +1,5 @@
-//// See LICENSE for license details.
-//
+// See LICENSE for license details.
+
 package examples
 
 import chisel3.core._


### PR DESCRIPTION
Treadle uses a slightly different BlackBox scala implementation scheme
This PR adds the required factory and new black box methods.
- All black boxes need getOutput method
- Separate Treadle version of factory added.
- Add this factory to the treadle options in Driver
- Removed extra resources that caused duplicate code erros with verilator in BlackBoxFloatSpec