### PR TITLE
Add mem model

### DIFF
--- a/rocket/src/main/scala/amba/apb/APBMasterModel.scala
+++ b/rocket/src/main/scala/amba/apb/APBMasterModel.scala
@@ -1,11 +1,12 @@
 // See LICENSE for license details
 
-package amba.apb
+package freechips.rocketchip.amba.apb
 
 import chisel3.experimental.MultiIOModule
+import dsptools.tester.MemMasterModel
 import freechips.rocketchip.amba.apb._
 
-trait APBMasterModel extends chisel3.iotesters.PeekPokeTester[MultiIOModule] {
+trait APBMasterModel extends chisel3.iotesters.PeekPokeTester[MultiIOModule] with MemMasterModel {
   def memAPB: APBBundle
 
   def apbReset(): Unit = {
@@ -16,6 +17,7 @@ trait APBMasterModel extends chisel3.iotesters.PeekPokeTester[MultiIOModule] {
   def apbWrite(addr: Int, data: Int): Unit =
     apbWrite(BigInt(addr), BigInt(data))
 
+  def memWriteWord(addr: BigInt, data: BigInt): Unit = apbWrite(addr, data)
   def apbWrite(addr: BigInt, data: BigInt): Unit = {
     var count = 0
     poke(memAPB.psel, 1)
@@ -36,6 +38,7 @@ trait APBMasterModel extends chisel3.iotesters.PeekPokeTester[MultiIOModule] {
     poke(memAPB.penable, 0)
   }
 
+  def memReadWord(addr: BigInt): BigInt = apbRead(addr)
   def apbRead(addr: Int): BigInt =
     apbRead(BigInt(addr))
 

--- a/rocket/src/main/scala/amba/axi4/AXI4MasterModel.scala
+++ b/rocket/src/main/scala/amba/axi4/AXI4MasterModel.scala
@@ -1,8 +1,9 @@
-package amba.axi4
+package freechips.rocketchip.amba.axi4
 
 import chisel3.experimental.MultiIOModule
 import chisel3.iotesters.PeekPokeTester
 import chisel3.util.IrrevocableIO
+import dsptools.tester.MemMasterModel
 import freechips.rocketchip.amba.axi4._
 
 object AXI4MasterModel {
@@ -61,7 +62,7 @@ object AXI4MasterModel {
   val RRESP_DECERR = BigInt(3)
 }
 
-trait AXI4MasterModel extends PeekPokeTester[MultiIOModule] {
+trait AXI4MasterModel extends PeekPokeTester[MultiIOModule] with MemMasterModel {
   import AXI4MasterModel._
 
   def memAXI: AXI4Bundle
@@ -134,6 +135,7 @@ trait AXI4MasterModel extends PeekPokeTester[MultiIOModule] {
     )
   }
 
+  def memWriteWord(addr: BigInt, data: BigInt): Unit = axiWriteWord(addr, data)
   def axiWriteWord(addr: BigInt, data: BigInt): Unit = {
     val awChannel = AWChannel(
       addr = addr,
@@ -190,6 +192,7 @@ trait AXI4MasterModel extends PeekPokeTester[MultiIOModule] {
     require(b.resp == BRESP_OKAY, s"BRESP not OKAY (got ${b.resp}")
 
   }
+  def memReadWord(addr: BigInt) = axiReadWord(addr)
   def axiReadWord(addr: BigInt): BigInt = {
     val arChannel = ARChannel(
       addr = addr,

--- a/rocket/src/main/scala/amba/axi4/StreamingSRAM.scala
+++ b/rocket/src/main/scala/amba/axi4/StreamingSRAM.scala
@@ -168,8 +168,7 @@ class StreamingAXI4DMA
 
 
     val readBufferHasSpace = readBuffer.entries.U - readBuffer.io.count > readDescriptor.length
-    // don't allow reading while a write is onging
-    axi.ar.valid := reading && !writing && !readAddrDone && readBufferHasSpace
+    axi.ar.valid := reading && !readAddrDone && readBufferHasSpace
     when (axi.ar.fire()) {
       readAddrDone := true.B
     }

--- a/rocket/src/main/scala/dspblocks/TestIP.scala
+++ b/rocket/src/main/scala/dspblocks/TestIP.scala
@@ -1,13 +1,13 @@
 package dspblocks
 
-import amba.apb.APBMasterModel
-import amba.axi4.AXI4MasterModel
 import breeze.math.Complex
 import chisel3._
 import chisel3.core.FixedPoint
 import chisel3.internal.firrtl.KnownBinaryPoint
 import dsptools._
 import dsptools.numbers._
+import freechips.rocketchip.amba.apb.APBMasterModel
+import freechips.rocketchip.amba.axi4.AXI4MasterModel
 import freechips.rocketchip.tilelink.TLMasterModel
 import spire.math.ConvertableFrom
 import spire.implicits._

--- a/rocket/src/main/scala/interrupts/Nodes.scala
+++ b/rocket/src/main/scala/interrupts/Nodes.scala
@@ -1,0 +1,58 @@
+package freechips.rocketchip.interrupts
+
+import chisel3._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+
+object IntBundleBridgeImp extends BundleBridgeImp[Vec[Bool]]
+
+case class IntToBundleBridgeNode(sinkParams: IntSinkPortParameters)(implicit valName: ValName)
+extends MixedAdapterNode(IntImp, IntBundleBridgeImp)(
+  dFn = { sourceParams =>
+    BundleBridgeParams(() => Vec(sinkParams.sinks.length, Bool()))
+  },
+  uFn = { sp => sinkParams }
+)
+
+class IntToBundleBridge(slaveParams: IntSinkPortParameters)(implicit p: Parameters)
+extends LazyModule {
+  val node = IntToBundleBridgeNode(slaveParams)
+
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, _), (out, _)) =>
+      out := in
+    }
+  }
+}
+
+object IntToBundleBridge {
+  def apply(sinkParams: IntSinkPortParameters)(implicit p: Parameters): IntToBundleBridgeNode =
+  {
+    val converter = LazyModule(new IntToBundleBridge(sinkParams))
+    converter.node
+  }
+}
+
+case class BundleBridgeToIntNode(sourceParams: IntSourcePortParameters)
+(implicit valName: ValName) extends MixedAdapterNode(IntBundleBridgeImp, IntImp)(
+  dFn = {sinkParams => sourceParams},
+  uFn = { slaveParams => BundleBridgeNull() }
+)
+
+class BundleBridgeToInt(sourceParams: IntSourcePortParameters)(implicit p: Parameters)
+extends LazyModule {
+  val node = BundleBridgeToIntNode(sourceParams)
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, _), (out, _)) =>
+      out := in
+    }
+  }
+}
+
+object BundleBridgeToInt {
+  def apply(sourceParams: IntSourcePortParameters)(implicit p: Parameters): BundleBridgeToIntNode =
+  {
+    val converter = LazyModule(new BundleBridgeToInt(sourceParams))
+    converter.node
+  }
+}

--- a/rocket/src/main/scala/tl/TestIP.scala
+++ b/rocket/src/main/scala/tl/TestIP.scala
@@ -3,6 +3,7 @@
 package freechips.rocketchip.tilelink
 
 import chisel3.experimental.MultiIOModule
+import dsptools.tester.MemMasterModel
 
 object TLMasterModel {
   case class AChannel(
@@ -46,7 +47,7 @@ object TLMasterModel {
 }
 
 //noinspection RedundantDefaultArgument
-trait TLMasterModel extends chisel3.iotesters.PeekPokeTester[MultiIOModule] {
+trait TLMasterModel extends chisel3.iotesters.PeekPokeTester[MultiIOModule] with MemMasterModel {
   import TLMasterModel._
 
   def memTL: TLBundle
@@ -186,6 +187,7 @@ trait TLMasterModel extends chisel3.iotesters.PeekPokeTester[MultiIOModule] {
     poke(memTL.e.valid, 0)
   }
 
+  def memWriteWord(addr: BigInt, data: BigInt): Unit = tlWriteWord(addr, data)
   def tlWriteWord(addr: BigInt, data: BigInt): Unit = {
     tlWriteA(AChannel(opcode = 0 /* PUT */, address=addr, data=data, mask = BigInt("1"*8, 2)))
     tlReadD()
@@ -202,6 +204,7 @@ trait TLMasterModel extends chisel3.iotesters.PeekPokeTester[MultiIOModule] {
     }
   }
 
+  def memReadWord(addr: BigInt): BigInt = tlReadWord(addr)
   def tlReadWord(addr: BigInt): BigInt = {
     tlWriteA(AChannel(opcode = 4 /* GET */, address=addr))
     val d = tlReadD()

--- a/rocket/src/test/scala/amba/axi4/StreamingMemoryTester.scala
+++ b/rocket/src/test/scala/amba/axi4/StreamingMemoryTester.scala
@@ -43,7 +43,12 @@ class StreamingMemoryTester(dut: StreamingMemory with AXI4StandaloneBlock, silen
   step(1)
   poke(dut.module.io.streamToMemRequest.valid, false)
 
-  stepToCompletion(silentFail = silentFail)
+  cycle = 0
+  while (peek(dut.module.io.writeComplete) != BigInt(1) && cycle < 100) {
+    cycle += 1
+    step(1)
+  }
+
   slave.addExpects((0 until 50 - 4).map(i => AXI4StreamTransactionExpect(data = Some(i + 3))))
 
   poke(mod.io.memToStreamRequest.bits.baseAddress, beatBytes * 4)

--- a/rocket/src/test/scala/dspblocks/DspRegisterSpec.scala
+++ b/rocket/src/test/scala/dspblocks/DspRegisterSpec.scala
@@ -1,6 +1,5 @@
 package dspblocks
 
-import amba.axi4.AXI4MasterModel
 import breeze.stats.distributions.Uniform
 import chisel3.core.Flipped
 import chisel3.iotesters.PeekPokeTester

--- a/rocket/src/test/scala/tester/MemMasterSpec.scala
+++ b/rocket/src/test/scala/tester/MemMasterSpec.scala
@@ -1,0 +1,152 @@
+package dsptools.tester
+
+import chisel3._
+import chisel3.experimental.MultiIOModule
+import chisel3.iotesters.PeekPokeTester
+import freechips.rocketchip.amba.apb._
+import freechips.rocketchip.amba.axi4._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.interrupts._
+import freechips.rocketchip.regmapper._
+import freechips.rocketchip.tilelink._
+import org.scalatest.{FlatSpec, Matchers}
+
+trait RegmapExample extends HasRegMap {
+  val r0 = RegInit(0.U(64.W))
+  val r1 = RegInit(1.U(64.W))
+
+  regmap(
+    0x00 -> Seq(RegField(64, r0)),
+    0x08 -> Seq(RegField(64, r1)),
+    0x10 -> Seq(RegField(64, r0)),
+    0x18 -> Seq(RegField(64, r1)),
+  )
+}
+
+
+
+class TLRegmapExample extends TLRegisterRouter(0, "example", Seq("dsptools", "example"), beatBytes = 8, interrupts = 1)(
+  new TLRegBundle(null, _))(
+    new TLRegModule(null, _, _) with RegmapExample)(Parameters.empty) {
+  def standaloneParams = TLBundleParameters(addressBits = 64, dataBits = 64, sourceBits = 1, sinkBits = 1, sizeBits = 6)
+
+  val ioMemNode = BundleBridgeSource(() => TLBundle(standaloneParams))
+  node :=
+    BundleBridgeToTL(TLClientPortParameters(Seq(TLClientParameters("bundleBridgeToTL")))) :=
+    ioMemNode
+  val ioMem = InModuleBody { ioMemNode.makeIO() }
+
+  val ioIntNode = BundleBridgeSink[Vec[Bool]]()
+  ioIntNode :=
+    IntToBundleBridge(IntSinkPortParameters(Seq(IntSinkParameters()))) :=
+      intnode
+  val ioInt = InModuleBody {
+    import chisel3.experimental.IO
+    val io = IO(Output(ioIntNode.bundle.cloneType))
+    io.suggestName("int")
+    io := ioIntNode.bundle
+    io
+  }
+}
+
+class AXI4RegmapExample extends AXI4RegisterRouter(0, beatBytes = 8, interrupts = 1)(
+  new AXI4RegBundle(null, _))(
+    new AXI4RegModule(null, _, _) with RegmapExample)(Parameters.empty) {
+  def standaloneParams = AXI4BundleParameters(addrBits = 64, dataBits = 64, idBits = 1, userBits = 0, wcorrupt = false)
+
+  val ioMemNode = BundleBridgeSource(() => AXI4Bundle(standaloneParams))
+  node :=
+    BundleBridgeToAXI4(AXI4MasterPortParameters(Seq(AXI4MasterParameters("bundleBridgeToAXI4")))) :=
+    ioMemNode
+  val ioMem = InModuleBody { ioMemNode.makeIO() }
+
+  val ioIntNode = BundleBridgeSink[Vec[Bool]]()
+  ioIntNode :=
+    IntToBundleBridge(IntSinkPortParameters(Seq(IntSinkParameters()))) :=
+      intnode
+  val ioInt = InModuleBody {
+    import chisel3.experimental.IO
+    val io = IO(Output(ioIntNode.bundle.cloneType))
+    io.suggestName("int")
+    io := ioIntNode.bundle
+    io
+  }
+}
+
+class APBRegmapExample extends APBRegisterRouter(0, beatBytes = 8, interrupts = 1)(
+  new APBRegBundle(null, _))(
+    new APBRegModule(null, _, _) with RegmapExample)(Parameters.empty) {
+  def standaloneParams = APBBundleParameters(addrBits = 64, dataBits = 64)
+
+  val ioMemNode = BundleBridgeSource(() => APBBundle(standaloneParams))
+  node :=
+    BundleBridgeToAPB(APBMasterPortParameters(Seq(APBMasterParameters("bundleBridgeToAPB")))) :=
+    ioMemNode
+  val ioMem = InModuleBody { ioMemNode.makeIO() }
+
+  val ioIntNode = BundleBridgeSink[Vec[Bool]]()
+  ioIntNode :=
+    IntToBundleBridge(IntSinkPortParameters(Seq(IntSinkParameters()))) :=
+      intnode
+  val ioInt = InModuleBody {
+    import chisel3.experimental.IO
+    val io = IO(Output(ioIntNode.bundle.cloneType))
+    io.suggestName("int")
+    io := ioIntNode.bundle
+    io
+  }
+}
+
+class MemMasterSpec extends FlatSpec with Matchers {
+  abstract class RegmapExampleTester[M <: MultiIOModule](c: M) extends PeekPokeTester(c) with MemMasterModel {
+    memReadWord(0x00) should be (0)
+    memReadWord(0x08) should be (1)
+    memReadWord(0x10) should be (0)
+    memReadWord(0x18) should be (1)
+    memWriteWord(0, 10)
+    memWriteWord(8, 5)
+    memReadWord(0x00) should be (10)
+    memReadWord(0x08) should be (5)
+    memReadWord(0x10) should be (10)
+    memReadWord(0x18) should be (5)
+  }
+
+  class TLRegmapExampleTester(c: TLRegmapExample) extends RegmapExampleTester(c.module)
+  with TLMasterModel {
+    def memTL = c.ioMem
+  }
+
+  class AXI4RegmapExampleTester(c: AXI4RegmapExample) extends RegmapExampleTester(c.module)
+  with AXI4MasterModel {
+    def memAXI = c.ioMem
+  }
+
+  class APBRegmapExampleTester(c: APBRegmapExample) extends RegmapExampleTester(c.module)
+  with APBMasterModel {
+    def memAPB = c.ioMem
+  }
+
+  behavior of "MemMaster Tester"
+
+  it should "work with TileLink" in {
+    lazy val dut = LazyModule(new TLRegmapExample)
+    chisel3.iotesters.Driver.execute(Array[String](), () => dut.module) { c =>
+      new TLRegmapExampleTester(dut)
+    }
+  }
+
+  it should "work with AXI-4" in {
+    lazy val dut = LazyModule(new AXI4RegmapExample)
+    chisel3.iotesters.Driver.execute(Array[String](), () => dut.module) { c =>
+      new AXI4RegmapExampleTester(dut)
+    }
+  }
+
+  it should "work with APB" in {
+    lazy val dut = LazyModule(new APBRegmapExample)
+    chisel3.iotesters.Driver.execute(Array[String](), () => dut.module) { c =>
+      new APBRegmapExampleTester(dut)
+    }
+  }
+}

--- a/src/main/scala/dsptools/tester/MemMasterModel.scala
+++ b/src/main/scala/dsptools/tester/MemMasterModel.scala
@@ -1,0 +1,9 @@
+package dsptools.tester
+
+trait MemMasterModel {
+  def memReadWord(addr: BigInt): BigInt
+  def memWriteWord(addr: BigInt, value: BigInt): Unit
+
+  def memReadWord(addr: Long): BigInt = memReadWord(BigInt(addr))
+  def memWriteWord(addr: Long, value: BigInt): Unit = memWriteWord(BigInt(addr), value)
+}


### PR DESCRIPTION
Unify existing master models for AXI4, TileLink, etc. with an abstract base class. Add an example test. It's a bit clunky- something is going on with interrupts under rocket.

The impact on vanilla (i.e. in `src`, *not* `rocket/src`) is small- just one added file `MemMasterModel.scala`.