### PR TITLE
Make DspComplex multiplies use growing addition.

### DIFF
--- a/src/test/scala/dsptools/numbers/DspComplexSpec.scala
+++ b/src/test/scala/dsptools/numbers/DspComplexSpec.scala
@@ -1,11 +1,11 @@
 // See LICENSE for license details.
 
-package dsptools.numbers
+package testing.dsptools.numbers
 
 import chisel3._
 import chisel3.iotesters.ChiselPropSpec
 import chisel3.testers.BasicTester
-import dsptools.numbers.implicits._
+import dsptools.numbers._
 
 //scalastyle:off magic.number
 class DspComplexExamples extends Module {


### PR DESCRIPTION
DspComplex relies on using the underlying Ring's multiplication. For UInt, SInt, FixedPoint, etc. these additions wrap instead of grow. For our implementation of complex multiplication, growing is more desirable
than wrapping.

This commit adds specialized versions of the DspComplex for UInt, SInt, FixedPoint, etc. that use growing addition.

This is in response to an issue @mkosunen and @yuedai14 were running into that they were working around by increasing input bitwidth.

@shunshou, what do you think?