### PR TITLE
Support stage/phase OptionsException wrapping.

### DIFF
--- a/src/test/scala/dsptools/numbers/NumbersSpec.scala
+++ b/src/test/scala/dsptools/numbers/NumbersSpec.scala
@@ -45,11 +45,12 @@ class NumbersSpec extends FreeSpec with Matchers {
           } should be(true)
         }
         "UInt subtract with overflow type Grow not supported" in {
-          intercept[DspException] {
+          val exception = intercept[Exception] {
             dsptools.Driver.execute(() => new BadUIntSubtractWithGrow2(u(4))) { c =>
               new NumbersEmptyTester(c)
-            } should be(true)
+            }
           }
+          exception.getCause should be(new DspException("OverflowType Grow is not supported for UInt subtraction"))
         }
         "UInt subtract with overflow type Grow not supported cannot be detected without evidence that io is ring" in {
           dsptools.Driver.execute(() => new ShouldBeBadUIntSubtractWithGrow) { c =>

--- a/src/test/scala/dsptools/numbers/NumbersSpec.scala
+++ b/src/test/scala/dsptools/numbers/NumbersSpec.scala
@@ -45,13 +45,17 @@ class NumbersSpec extends FreeSpec with Matchers {
           } should be(true)
         }
         "UInt subtract with overflow type Grow not supported" in {
+          val expectedMessage = "OverflowType Grow is not supported for UInt subtraction"
           val exception = intercept[Exception] {
             dsptools.Driver.execute(() => new BadUIntSubtractWithGrow2(u(4))) { c =>
               new NumbersEmptyTester(c)
             }
           }
-          exception.getCause should be(new DspException("OverflowType Grow is not supported for UInt subtraction"))
-        }
+          exception match {
+            case e: DspException => e.getMessage should be(expectedMessage)
+            case e: Exception => exception.getCause should be(new DspException(expectedMessage))
+          }
+         }
         "UInt subtract with overflow type Grow not supported cannot be detected without evidence that io is ring" in {
           dsptools.Driver.execute(() => new ShouldBeBadUIntSubtractWithGrow) { c =>
             new NumbersEmptyTester(c)


### PR DESCRIPTION
Test the exception cause in the "UInt subtract with overflow type Grow not supported" test (since stage/phase code will wrap it in an OptionsException).