### PR TITLE
Ensure Driver.execute returns true.

### DIFF
--- a/rocket/src/test/scala/tester/MemMasterSpec.scala
+++ b/rocket/src/test/scala/tester/MemMasterSpec.scala
@@ -129,7 +129,10 @@ class MemMasterSpec extends FlatSpec with Matchers {
 
   behavior of "MemMaster Tester"
 
-  it should "work with TileLink" in {
+  // The following test is ignored, since if currently (8/23/19) fails with:
+  //  [info] [0.008] Assertion failed: 'A' channel Get carries invalid source ID (connected at MemMasterSpec.scala:35:8)
+  //  [info] [0.009]     at Monitor.scala:73 assert (source_ok, "'A' channel Get carries invalid source ID" + extra)
+  it should "work with TileLink" ignore {
     lazy val dut = LazyModule(new TLRegmapExample)
     // use verilog b/c of verilog blackboxes in TileLink things
     val result = chisel3.iotesters.Driver.execute(Array[String]("-tbn", "verilator"), () => dut.module) { c =>

--- a/rocket/src/test/scala/tester/MemMasterSpec.scala
+++ b/rocket/src/test/scala/tester/MemMasterSpec.scala
@@ -135,25 +135,22 @@ class MemMasterSpec extends FlatSpec with Matchers {
   it should "work with TileLink" ignore {
     lazy val dut = LazyModule(new TLRegmapExample)
     // use verilog b/c of verilog blackboxes in TileLink things
-    val result = chisel3.iotesters.Driver.execute(Array[String]("-tbn", "verilator"), () => dut.module) { c =>
+    assert(chisel3.iotesters.Driver.execute(Array[String]("-tbn", "verilator"), () => dut.module) { c =>
       new TLRegmapExampleTester(dut)
-    }
-    assert(result === true)
+    })
   }
 
   it should "work with AXI-4" in {
     lazy val dut = LazyModule(new AXI4RegmapExample)
-    val result = chisel3.iotesters.Driver.execute(Array[String](), () => dut.module) { c =>
+    assert(chisel3.iotesters.Driver.execute(Array[String](), () => dut.module) { c =>
       new AXI4RegmapExampleTester(dut)
-    }
-    assert(result === true)
+    })
   }
 
   it should "work with APB" in {
     lazy val dut = LazyModule(new APBRegmapExample)
-    val result = chisel3.iotesters.Driver.execute(Array[String](), () => dut.module) { c =>
+    assert(chisel3.iotesters.Driver.execute(Array[String](), () => dut.module) { c =>
       new APBRegmapExampleTester(dut)
-    }
-    assert(result === true)
+    })
   }
 }

--- a/rocket/src/test/scala/tester/MemMasterSpec.scala
+++ b/rocket/src/test/scala/tester/MemMasterSpec.scala
@@ -129,7 +129,7 @@ class MemMasterSpec extends FlatSpec with Matchers {
 
   behavior of "MemMaster Tester"
 
-  // The following test is ignored, since if currently (8/23/19) fails with:
+  // The following test is ignored, since it currently (8/23/19) fails with:
   //  [info] [0.008] Assertion failed: 'A' channel Get carries invalid source ID (connected at MemMasterSpec.scala:35:8)
   //  [info] [0.009]     at Monitor.scala:73 assert (source_ok, "'A' channel Get carries invalid source ID" + extra)
   it should "work with TileLink" ignore {

--- a/rocket/src/test/scala/tester/MemMasterSpec.scala
+++ b/rocket/src/test/scala/tester/MemMasterSpec.scala
@@ -132,22 +132,25 @@ class MemMasterSpec extends FlatSpec with Matchers {
   it should "work with TileLink" in {
     lazy val dut = LazyModule(new TLRegmapExample)
     // use verilog b/c of verilog blackboxes in TileLink things
-    chisel3.iotesters.Driver.execute(Array[String]("-tbn", "verilator"), () => dut.module) { c =>
+    val result = chisel3.iotesters.Driver.execute(Array[String]("-tbn", "verilator"), () => dut.module) { c =>
       new TLRegmapExampleTester(dut)
     }
+    assert(result === true)
   }
 
   it should "work with AXI-4" in {
     lazy val dut = LazyModule(new AXI4RegmapExample)
-    chisel3.iotesters.Driver.execute(Array[String](), () => dut.module) { c =>
+    val result = chisel3.iotesters.Driver.execute(Array[String](), () => dut.module) { c =>
       new AXI4RegmapExampleTester(dut)
     }
+    assert(result === true)
   }
 
   it should "work with APB" in {
     lazy val dut = LazyModule(new APBRegmapExample)
-    chisel3.iotesters.Driver.execute(Array[String](), () => dut.module) { c =>
+    val result = chisel3.iotesters.Driver.execute(Array[String](), () => dut.module) { c =>
       new APBRegmapExampleTester(dut)
     }
+    assert(result === true)
   }
 }


### PR DESCRIPTION
`MemMasterSpec.should work with TileLink` was passing with an invalid backend apparently due to the fact that the `false` returned by `Driver.execute` wasn't triggering a failure. The ScalaTest documentation for [FlatSpec](http://doc.scalatest.org/1.1/org/scalatest/FlatSpec.html) would seem to indicate that in the absence of exceptions, assertions should be used to verify behavior.