### PR TITLE
Update MuxInOuts trait to take into account change to diplomacy.Nodes.scala:makeIOs

### DIFF
--- a/rocket/src/test/scala/amba/axi4stream/AXI4StreamSpec.scala
+++ b/rocket/src/test/scala/amba/axi4stream/AXI4StreamSpec.scala
@@ -85,15 +85,15 @@ trait MuxInOuts[D, U, EO, EI, B <: Data] {
   def nIn: Int
   def nOut: Int
 
-  val ins: Seq[ModuleValue[AXI4StreamBundle]] = for (_ <- 0 until nIn) yield {
-    val in = BundleBridgeSource(() => AXI4StreamBundle(AXI4StreamBundleParameters(n = 8)))
+  val ins: Seq[ModuleValue[AXI4StreamBundle]] = for (i <- 0 until nIn) yield {
+    implicit val valName = ValName(s"inIOs_$i")
+    val in = BundleBridgeSource[AXI4StreamBundle](() => AXI4StreamBundle(AXI4StreamBundleParameters(n = 8)))
     streamNode :=
       BundleBridgeToAXI4Stream(AXI4StreamMasterPortParameters(AXI4StreamMasterParameters())) :=
       in
     InModuleBody { in.makeIO() }
   }
   val outIOs: Seq[ModuleValue[AXI4StreamBundle]] = for (o <- 0 until nOut) yield {
-    // it's strange to me that this is evidently needed for the outputs but not the inputs...
     implicit val valName = ValName(s"outIOs_$o")
     val out = BundleBridgeSink[AXI4StreamBundle]()
     out :=


### PR DESCRIPTION
chipsalliance/rocket-chip#2201 updated makeIOs resulting in rocket-dsptools test failurs:
```
[info] - should work with 1 masters and 4 slaves
[info] - should work with 1 masters and 5 slaves
[info] - should work with 2 masters and 1 slaves *** FAILED ***
[info]   java.lang.Exception: Problem with compilation
[info]   at chisel3.iotesters.setupTreadleBackend$.apply(TreadleBackend.scala:152)
[info]   at chisel3.iotesters.Driver$.$anonfun$execute$2(Driver.scala:53)
[info]   at scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.java:23)
```
ostensibly due to:
```
[error] RawModule.scala:48: Unable to name port AXI4StreamBundle(IO ins_1 in AXI4StreamMux) to "ins" in freechips.rocketchip.amba.axi4stream.StreamMux$$anon$1@61e5a5c9, name is already taken by another port! in class chisel3.RawModule
```
Try to fix this by copying the code from outIOs and delete the comment:
```scala
    // it's strange to me that this is evidently needed for the outputs but not the inputs...
```