### PR TITLE
Fix peekAt argument type.

### DIFF
--- a/src/main/scala/dsptools/tester/DspTester.scala
+++ b/src/main/scala/dsptools/tester/DspTester.scala
@@ -77,7 +77,7 @@ class DspTester[+T <: MultiIOModule](
   }
 
   // Poke at does not involve external signals -- no VerilogTB print
-  override def pokeAt[TT <: Element : Pokeable](data: Mem[TT], value: BigInt, off: Int): Unit = {
+  override def pokeAt[TT <: Element : Pokeable](data: MemBase[TT], value: BigInt, off: Int): Unit = {
     backend.poke(data, value, Some(off))(logger, dispDsp, dispBase)
   }
 
@@ -109,7 +109,7 @@ class DspTester[+T <: MultiIOModule](
   }
 
   // Peek at does not involve external signals -- no VerilogTB print
-  override def peekAt[TT <: Element : Pokeable](data: Mem[TT], off: Int): BigInt = {
+  override def peekAt[TT <: Element : Pokeable](data: MemBase[TT], off: Int): BigInt = {
     backend.peek(data, Some(off))(logger, dispDsp, dispBase)
   }
 


### PR DESCRIPTION
freechipsproject/chisel-testers#274 changed the argument to pokeAt from`'Mem` to `MemBase`. Do the same here.