### PR TITLE
Change log defaults text from "error" to "warn"

### DIFF
--- a/src/test/scala/dsptools/LoggingSpec.scala
+++ b/src/test/scala/dsptools/LoggingSpec.scala
@@ -20,7 +20,7 @@ class DutWithLoggingTester(c: DutWithLogging) extends DspTester(c)
 
 class LoggingSpec extends FreeSpec with Matchers {
   "logging can be emitted during hardware generation" - {
-    "level defaults to error" in {
+    "level defaults to warn" in {
       Logger.makeScope() {
         val captor = new Logger.OutputCaptor
         Logger.setOutput(captor.printStream)


### PR DESCRIPTION
NOTE: This currently fails Travis checks since it requires an updated FIRRTL containing the associated global log level change.
