### PR TITLE
Inherit DspException from ChiselException

### DIFF
--- a/src/main/scala/dsptools/misc/DspException.scala
+++ b/src/main/scala/dsptools/misc/DspException.scala
@@ -2,5 +2,7 @@
 
 package dsptools
 
-case class DspException(message: String) extends Exception(message) {
+import chisel3.ChiselException
+
+case class DspException(message: String) extends ChiselException(message) {
 }


### PR DESCRIPTION
In preparation for future changes to chisel exception handling, ensure DspException inherits from ChiselException.