### PR TITLE
Ignore NumbersSpec tests that rely on throwing DspExceptions.

### DIFF
--- a/src/test/scala/dsptools/numbers/NumbersSpec.scala
+++ b/src/test/scala/dsptools/numbers/NumbersSpec.scala
@@ -44,7 +44,7 @@ class NumbersSpec extends FreeSpec with Matchers {
             )
           } should be(true)
         }
-        "UInt subtract with overflow type Grow not supported" in {
+        "UInt subtract with overflow type Grow not supported" ignore {
           val expectedMessage = "OverflowType Grow is not supported for UInt subtraction"
           val exception = intercept[Exception] {
             dsptools.Driver.execute(() => new BadUIntSubtractWithGrow2(u(4))) { c =>


### PR DESCRIPTION
Stage/Phase support in chisel3 currently causes exceptions to be absorbed and converted to execution failures with the initial cause hidden. Ignore tests that rely on being able to catch DspExceptions pending conversion from the old Driver interface and definition of a Chisel Exception API.