### PR TITLE
Add Interval support

### DIFF
--- a/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
+++ b/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
@@ -3,7 +3,7 @@
 package dsptools.numbers
 
 import chisel3._
-import chisel3.experimental.FixedPoint
+import chisel3.experimental.{FixedPoint, Interval}
 import dsptools.DspException
 import implicits._
 import breeze.math.Complex
@@ -77,10 +77,11 @@ class DspComplex[T <: Data:Ring](val real: T, val imag: T) extends Bundle {
 
   def underlyingType(dummy: Int = 0): String = {
     real match {
-      case f: FixedPoint => "fixed"
-      case r: DspReal    => "real"
-      case s: SInt       => "SInt"
-      case u: UInt       => "UInt"
+      case _: Interval   => "interval"
+      case _: FixedPoint => "fixed"
+      case _: DspReal    => "real"
+      case _: SInt       => "SInt"
+      case _: UInt       => "UInt"
       case _ => throw DspException(s"DspComplex found unsupported underlying type: ${real.getClass.getName}")
     }
   }

--- a/src/main/scala/dsptools/numbers/chisel_types/FixedPointTypeClass.scala
+++ b/src/main/scala/dsptools/numbers/chisel_types/FixedPointTypeClass.scala
@@ -3,10 +3,10 @@
 package dsptools.numbers
 
 import chisel3._
-import chisel3.util.{Cat, ShiftRegister}
-import dsptools.{DspContext, DspException, Grow, NoTrim, RoundDown, RoundHalfDown, RoundHalfToEven, RoundHalfToOdd, RoundHalfTowardsInfinity, RoundHalfTowardsZero, RoundHalfUp, RoundTowardsInfinity, RoundTowardsZero, RoundUp, Saturate, Wrap, hasContext}
 import chisel3.experimental.{FixedPoint, Interval}
 import chisel3.internal.firrtl.{IntervalRange, KnownBinaryPoint}
+import chisel3.util.ShiftRegister
+import dsptools._
 
 import scala.language.implicitConversions
 

--- a/src/main/scala/dsptools/numbers/chisel_types/FixedPointTypeClass.scala
+++ b/src/main/scala/dsptools/numbers/chisel_types/FixedPointTypeClass.scala
@@ -3,10 +3,11 @@
 package dsptools.numbers
 
 import chisel3._
-import chisel3.util.{ShiftRegister, Cat}
-import dsptools.{hasContext, DspContext, Grow, Wrap, Saturate, NoTrim, RoundDown, RoundUp, RoundTowardsZero, RoundTowardsInfinity, RoundHalfDown, RoundHalfUp, RoundHalfTowardsZero, RoundHalfTowardsInfinity, RoundHalfToEven, RoundHalfToOdd, DspException}
-import chisel3.experimental.FixedPoint
-import chisel3.internal.firrtl.KnownBinaryPoint
+import chisel3.util.{Cat, ShiftRegister}
+import dsptools.{DspContext, DspException, Grow, NoTrim, RoundDown, RoundHalfDown, RoundHalfToEven, RoundHalfToOdd, RoundHalfTowardsInfinity, RoundHalfTowardsZero, RoundHalfUp, RoundTowardsInfinity, RoundTowardsZero, RoundUp, Saturate, Wrap, hasContext}
+import chisel3.experimental.{FixedPoint, Interval}
+import chisel3.internal.firrtl.{IntervalRange, KnownBinaryPoint}
+
 import scala.language.implicitConversions
 
 //scalastyle:off method.name
@@ -107,6 +108,8 @@ trait ConvertableFromFixedPoint extends ChiselConvertableFrom[FixedPoint] with h
   // asReal depends on shifting fractional bits up
   override def asFixed(a: FixedPoint): FixedPoint = a
   def asFixed(a: FixedPoint, proto: FixedPoint): FixedPoint = asFixed(a)
+  override def asInterval(a: FixedPoint): Interval = a.asInterval(IntervalRange(a.binaryPoint))
+  def asInterval(a: FixedPoint, proto: Interval): Interval = a.asInterval(proto.range)
 }
 
 trait BinaryRepresentationFixedPoint extends BinaryRepresentation[FixedPoint] with hasContext {

--- a/src/main/scala/dsptools/numbers/chisel_types/IntervalTypeClass.scala
+++ b/src/main/scala/dsptools/numbers/chisel_types/IntervalTypeClass.scala
@@ -1,0 +1,278 @@
+// See LICENSE for license details.
+
+package dsptools.numbers.chisel_types
+
+import chisel3._
+import chisel3.experimental.{FixedPoint, Interval}
+import chisel3.internal.firrtl.KnownBinaryPoint
+import chisel3.util.ShiftRegister
+import dsptools.numbers.{
+  BinaryRepresentation, ChiselConvertableFrom, ComparisonBundle, ComparisonHelper,
+  ConvertableFrom, ConvertableTo, DspReal, IsReal, Order, RealBits, Ring, Signed
+}
+import dsptools._
+
+import scala.language.implicitConversions
+
+//scalastyle:off method.name
+
+/**
+  * Defines basic math functions for Interval numbers
+  */
+trait IntervalRing extends Any with Ring[Interval] with hasContext {
+  def zero: Interval = Interval.Zero
+  def one: Interval= 1.0.I(0.BP)
+  def plus(f: Interval, g: Interval): Interval = f + g
+  def plusContext(f: Interval, g: Interval): Interval = {
+    // TODO: Saturating mux should be outside of ShiftRegister
+    val sum = context.overflowType match {
+      case Grow => f +& g
+      case Wrap => f +% g
+      case _ => throw DspException("Saturating add hasn't been implemented")
+    }
+    ShiftRegister(sum, context.numAddPipes)
+  }
+  override def minus(f: Interval, g: Interval): Interval = f - g
+  def minusContext(f: Interval, g: Interval): Interval = {
+    val diff = context.overflowType match {
+      case Grow => f -& g
+      case Wrap => f -% g
+      case _ => throw DspException("Saturating subtractor hasn't been implemented")
+    }
+    ShiftRegister(diff, context.numAddPipes)
+  }
+  def negate(f: Interval): Interval = -(f)
+  def negateContext(f: Interval): Interval = minus(zero, f)
+
+  def times(f: Interval, g: Interval): Interval = f * g
+
+  // timesContext moved later b/c need trim binary
+}
+
+trait IntervalOrder extends Any with Order[Interval] with hasContext {
+  override def compare(x: Interval, y: Interval): ComparisonBundle = {
+    ComparisonHelper(x === y, x < y)
+  }
+  override def eqv(x: Interval, y: Interval): Bool = x === y
+  override def neqv(x: Interval, y:Interval): Bool = x =/= y
+  override def lt(x: Interval, y: Interval): Bool = x < y
+  override def lteqv(x: Interval, y: Interval): Bool = x <= y
+  override def gt(x: Interval, y: Interval): Bool = x > y
+  override def gteqv(x: Interval, y: Interval): Bool = x >= y
+  // min, max depends on lt, gt & mux
+}
+
+trait IntervalSigned extends Any with Signed[Interval] with hasContext {
+  // isSignPositive, isSignNonZero, isSignNonPositive, isSignNonNegative derived from above (!)
+  // abs requires ring (for overflow) so overridden later
+  // isSignZero, isSignNegative moved to IntervalReal to get access to 'zero'
+}
+
+trait IntervalIsReal extends Any with IsReal[Interval] with IntervalOrder with IntervalSigned with hasContext {
+  // Chop off fractional bits --> round to negative infinity
+  def floor(a: Interval): Interval = a.setPrecision(0)
+  def isWhole(a: Interval): Bool = a === floor(a)
+  // Truncate = round towards zero (integer part without fractional bits)
+  def truncate(a: Interval): Interval = {
+    Mux(isSignNegative(ShiftRegister(a, context.numAddPipes)),
+      ceil(a),
+      floor(ShiftRegister(a, context.numAddPipes))
+    )
+  }
+  // ceil, round moved to IntervalReal to get access to ring
+}
+
+trait ConvertableToInterval extends ConvertableTo[Interval] with hasContext {
+  def fromShort(n: Short): Interval = fromInt(n.toInt)
+  def fromByte(n: Byte): Interval = fromInt(n.toInt)
+  def fromInt(n: Int): Interval = fromBigInt(BigInt(n))
+  def fromFloat(n: Float): Interval = fromDouble(n.toDouble)
+  def fromBigDecimal(n: BigDecimal): Interval = fromDouble(n.doubleValue)
+  def fromLong(n: Long): Interval = fromBigInt(BigInt(n))
+  def fromType[B](n: B)(implicit c: ConvertableFrom[B]): Interval = fromDouble(c.toDouble(n))
+  def fromBigInt(n: BigInt): Interval = n.doubleValue.I(0.BP)
+  // If no binary point is specified, use the default one provided by DspContext
+  // TODO: Should you instead be specifying a max width so you can get the most resolution for a given width?
+  def fromDouble(n: Double): Interval = n.I(context.binaryPoint.getOrElse(0).BP)
+  override def fromDouble(d: Double, a: Interval): Interval = {
+    require(a.binaryPoint.known, "Binary point must be known!")
+    d.I(a.binaryPoint)
+  }
+  override def fromDoubleWithFixedWidth(d: Double, a: Interval): Interval = {
+    require(a.binaryPoint.known, "Binary point must be known!")
+    require(a.widthKnown, "Interval width not known!")
+    val sintBits = BigInt(d.toInt).bitLength + 1
+    require(sintBits + a.binaryPoint.get <= a.getWidth, "Lit can't fit in prototype Interval bitwidth")
+    d.I(a.getWidth.W, a.binaryPoint)
+  }
+}
+
+trait ConvertableFromInterval extends ChiselConvertableFrom[Interval] with hasContext {
+  // intPart depends on truncate
+  // asReal depends on shifting fractional bits up
+
+  override def asFixed(a: Interval): FixedPoint = a.asFixedPoint(a.binaryPoint)
+  def asFixed(a: Interval, proto: FixedPoint): FixedPoint = a.asFixedPoint(proto.binaryPoint)
+
+  override def asInterval(a: Interval): Interval = a
+  def asInterval(a: Interval, proto: Interval): Interval = asInterval(a)
+}
+
+trait BinaryRepresentationInterval extends BinaryRepresentation[Interval] with hasContext {
+  def shl(a: Interval, n: Int): Interval = a << n
+  def shl(a: Interval, n: UInt): Interval = a << n
+
+  // Note: This rounds to negative infinity (smallest abs. value for negative #'s is -LSB)
+  def shr(a: Interval, n: Int): Interval = a >> n
+  def shr(a: Interval, n: UInt): Interval = a >> n
+
+  // mul2 consistent with shl
+  // signBit relies on Signed
+
+  // Retains significant digits while dividing
+  override def div2(a: Interval, n: Int): Interval = {
+    require(a.widthKnown, "Interval point width must be known for div2")
+    require(a.binaryPoint.known, "Binary point must be known for div2")
+    val newBP = a.binaryPoint.get + n
+    // Normal shift loses significant digits; this version doesn't
+    val inLong = Wire(Interval((a.getWidth + n).W, newBP.BP))
+    inLong := a
+    val outFull = Wire(Interval(a.getWidth.W, newBP.BP))
+    // Upper n bits don't contain meaningful data following shift, so remove
+    outFull := inLong >> n
+    // Note: The above doesn't rely on tools to expand, shrink correctly; the version below does.
+    // Assumes setBinaryPoint zero-extends. BUT Chisel doesn't seem to get widths properly and
+    // some other ops rely on width correctness... (even though Firrtl is right...)
+    //a.setBinaryPoint(newBP) >> n
+    trimBinary(outFull, Some(a.binaryPoint.get + context.binaryPointGrowth))
+  }
+  // trimBinary below for access to ring ops
+
+ }
+
+trait IntervalReal extends IntervalRing with IntervalIsReal with ConvertableToInterval with
+    ConvertableFromInterval with BinaryRepresentationInterval with RealBits[Interval] with hasContext {
+
+  def trimBinary(a: Interval, n: Option[Int]): Interval = {
+    // TODO: Support other modes?
+    n match {
+      case None => a
+      case Some(b) => context.trimType match {
+        case NoTrim => a
+        case RoundDown => a.setPrecision(b)
+        case RoundUp => {
+          val addAmt = math.pow(2, -b).I(b.BP) // shr(1.0.I(b.BP),b)
+          Mux((a === a.setPrecision(b)), a.setPrecision(b), plus(a.setPrecision(b), addAmt))
+        }
+        case RoundTowardsZero => {
+          val addAmt = math.pow(2, -b).I(b.BP) // shr(1.0.I(b.BP),b)
+          val valueForNegativeNum = Mux((a === a.setPrecision(b)), a.setPrecision(b), plus(a.setPrecision(b), addAmt))
+          Mux(isSignNegative(a), valueForNegativeNum, a.setPrecision(b))
+        }
+        case RoundTowardsInfinity => {
+          val addAmt = math.pow(2, -b).I(b.BP) // shr(1.0.I(b.BP),b)
+          val valueForPositiveNum = Mux((a === a.setPrecision(b)), a.setPrecision(b), plus(a.setPrecision(b), addAmt))
+          Mux(isSignNegative(a), a.setPrecision(b), valueForPositiveNum)
+        }
+        case RoundHalfDown => {
+          val addAmt1 = math.pow(2, -b).I(b.BP) // shr(1.0.I(b.BP),b)
+          val addAmt2 = math.pow(2, -(b+1)).I((b+1).BP) // shr(1.0.I((b+1).BP),(b+1))
+          Mux((a > plus(a.setPrecision(b), addAmt2)), plus(a.setPrecision(b), addAmt1), a.setPrecision(b))
+        }
+        case RoundHalfUp => {
+          val roundBp = b + 1
+          val addAmt = math.pow(2, -roundBp).I(roundBp.BP)
+          plus(a, addAmt).setPrecision(b)
+        }
+        case RoundHalfTowardsZero => {
+          val addAmt1 = math.pow(2, -b).I(b.BP) // shr(1.0.I(b.BP),b)
+          val addAmt2 = math.pow(2, -(b+1)).I((b+1).BP) // shr(1.0.I((b+1).BP),(b+1))
+          val valueForPositiveNum = Mux((a > plus(a.setPrecision(b), addAmt2)), plus(a.setPrecision(b), addAmt1), a.setPrecision(b))
+          Mux(isSignNegative(a), plus(a, addAmt2).setPrecision(b), valueForPositiveNum)
+        }
+        case RoundHalfTowardsInfinity => {
+          val roundBp = b + 1
+          val addAmt = math.pow(2, -roundBp).I(roundBp.BP)
+          Mux(isSignNegative(a) && (a === a.setPrecision(roundBp)), a.setPrecision(b), plus(a, addAmt).setPrecision(b))
+        }
+        case RoundHalfToEven => {
+          require(b > 0, "Binary point of input fixed point number must be larger than zero when trimming")
+          val roundBp = b + 1
+          val checkIfEvenBp = b - 1
+          val addAmt = math.pow(2, -roundBp).I(roundBp.BP)
+          Mux((a.setPrecision(checkIfEvenBp) === a.setPrecision(b)) && (a === a.setPrecision(roundBp)), a.setPrecision(b), plus(a, addAmt).setPrecision(b))
+        }
+        case RoundHalfToOdd => {
+          require(b > 0, "Binary point of input fixed point number must be larger than zero when trimming")
+          val roundBp = b + 1
+          val checkIfOddBp = b - 1
+          val addAmt = math.pow(2, -roundBp).I(roundBp.BP)
+          Mux((a.setPrecision(checkIfOddBp) =/= a.setPrecision(b)) && (a === a.setPrecision(roundBp)), a.setPrecision(b), plus(a, addAmt).setPrecision(b))
+        }
+        case _ => throw DspException("Desired trim type not implemented!")
+      }
+    }
+  }
+
+  def timesContext(f: Interval, g: Interval): Interval = {
+    // TODO: Overflow via ranging in FIRRTL?
+    // Rounding after registering to make retiming easier to recognize
+    val outTemp = ShiftRegister(f * g, context.numMulPipes)
+    val newBP = (f.binaryPoint, g.binaryPoint) match {
+      case (KnownBinaryPoint(i), KnownBinaryPoint(j)) => Some(i.max(j) + context.binaryPointGrowth)
+      case (_, _) => None
+    }
+    trimBinary(outTemp, newBP)
+  }
+
+  def signum(a: Interval): ComparisonBundle = {
+    ComparisonHelper(a === zero, a < zero)
+  }
+  override def isSignZero(a: Interval): Bool = a === zero
+  override def isSignNegative(a:Interval): Bool = {
+    if (a.widthKnown) a(a.getWidth-1)
+    else a < zero
+  }
+
+  // Can potentially overflow
+  def ceil(a: Interval): Interval = {
+    Mux(
+      isWhole(ShiftRegister(a, context.numAddPipes)),
+      floor(ShiftRegister(a, context.numAddPipes)),
+      plusContext(floor(a), one))
+  }
+  def context_ceil(a: Interval): Interval = ceil(a)
+
+  // Round half up: Can potentially overflow [round half towards positive infinity]
+  // NOTE: Apparently different from Java for negatives
+  def round(a: Interval): Interval = floor(plusContext(a, 0.5.I(1.BP)))
+
+  def signBit(a: Interval): Bool = isSignNegative(a)
+  // fromInterval also included in Ring
+  override def fromInt(n: Int): Interval = super[ConvertableToInterval].fromInt(n)
+  override def fromBigInt(n: BigInt): Interval = super[ConvertableToInterval].fromBigInt(n)
+  // Overflow only on most negative
+  def abs(a: Interval): Interval = {
+    Mux(isSignNegative(a), super[IntervalRing].minus(zero, a), a)
+  }
+  def context_abs(a: Interval): Interval = {
+    Mux(
+      isSignNegative(ShiftRegister(a, context.numAddPipes)),
+      super[IntervalRing].minusContext(zero, a),
+      ShiftRegister(a, context.numAddPipes))
+  }
+
+  def intPart(a: Interval): SInt = truncate(a).asSInt
+
+  // Converts to DspReal
+  def asReal(a: Interval): DspReal = {
+    require(a.binaryPoint.known, "Binary point must be known for asReal")
+    val n = a.binaryPoint.get
+    val normalizedInt = a << n
+    DspReal(floor(normalizedInt).asSInt)/DspReal((1 << n).toDouble)
+  }
+}
+
+trait IntervalImpl {
+  implicit object IntervalRealImpl extends IntervalReal
+}

--- a/src/main/scala/dsptools/numbers/chisel_types/SIntTypeClass.scala
+++ b/src/main/scala/dsptools/numbers/chisel_types/SIntTypeClass.scala
@@ -5,7 +5,8 @@ package dsptools.numbers
 import chisel3._
 import chisel3.util.{Cat, ShiftRegister}
 import dsptools.{DspContext, DspException, Grow, NoTrim, Saturate, Wrap, hasContext}
-import chisel3.experimental.FixedPoint
+import chisel3.experimental.{FixedPoint, Interval}
+import chisel3.internal.firrtl.IntervalRange
 
 import scala.language.implicitConversions
 
@@ -110,6 +111,11 @@ trait ConvertableToSInt extends ConvertableTo[SInt] with hasContext {
 
 trait ConvertableFromSInt extends ChiselConvertableFrom[SInt] with hasContext {
   def intPart(a: SInt): SInt = a
+
+  // Converts to Interval with 0 fractional bits (Note: proto only used for real)
+  override def asInterval(a: SInt): Interval = a.asInterval(IntervalRange(0.BP))
+  def asInterval(a: SInt, proto: Interval): Interval = a.asInterval(proto.range)
+
   // Converts to FixedPoint with 0 fractional bits (Note: proto only used for real)
   override def asFixed(a: SInt): FixedPoint = a.asFixedPoint(0.BP)
   def asFixed(a: SInt, proto: FixedPoint): FixedPoint = asFixed(a)

--- a/src/main/scala/dsptools/numbers/chisel_types/UIntTypeClass.scala
+++ b/src/main/scala/dsptools/numbers/chisel_types/UIntTypeClass.scala
@@ -3,9 +3,10 @@
 package dsptools.numbers
 
 import chisel3._
-import chisel3.util.{ShiftRegister, Cat}
-import dsptools.{hasContext, DspContext, Grow, Wrap, Saturate, DspException}
-import chisel3.experimental.FixedPoint
+import chisel3.util.{Cat, ShiftRegister}
+import dsptools.{DspContext, DspException, Grow, Saturate, Wrap, hasContext}
+import chisel3.experimental.{FixedPoint, Interval}
+import chisel3.internal.firrtl.IntervalRange
 
 import scala.language.implicitConversions
 
@@ -112,6 +113,11 @@ trait ConvertableToUInt extends ConvertableTo[UInt] with hasContext {
 trait ConvertableFromUInt extends ChiselConvertableFrom[UInt] with hasContext {
   // Bit grow by 1, but always positive to maintain correctness
   def intPart(a: UInt): SInt = Cat(false.B, a).asSInt
+
+  // Converts to Interval with 0 fractional bits (second arg only used for DspReal)
+  override def asInterval(a: UInt): Interval = intPart(a).asInterval(IntervalRange(0.BP))
+  def asInterval(a: UInt, proto: Interval): Interval = intPart(a).asInterval(proto.range)
+
   // Converts to FixedPoint with 0 fractional bits (second arg only used for DspReal)
   override def asFixed(a: UInt): FixedPoint = intPart(a).asFixedPoint(0.BP)
   def asFixed(a: UInt, proto: FixedPoint): FixedPoint = asFixed(a)

--- a/src/main/scala/dsptools/numbers/convertible_types/ChiselConvertableFrom.scala
+++ b/src/main/scala/dsptools/numbers/convertible_types/ChiselConvertableFrom.scala
@@ -1,7 +1,9 @@
+// See LICENSE for license details.
+
 package dsptools.numbers
 
+import chisel3.experimental.{FixedPoint, Interval}
 import chisel3.{Data, SInt}
-import chisel3.experimental.FixedPoint
 import dsptools.DspException
 
 object ChiselConvertableFrom {
@@ -10,7 +12,12 @@ object ChiselConvertableFrom {
 
 trait ChiselConvertableFrom[A <: Data] extends Any {
   def intPart(a: A): SInt
+
+  def asInterval(a: A, proto: Interval): Interval
+  def asInterval(a: A): Interval = throw DspException("As fixed needs prototype argument!")
+
   def asFixed(a: A, proto: FixedPoint): FixedPoint
   def asFixed(a: A): FixedPoint = throw DspException("As fixed needs prototype argument!")
+
   def asReal(a: A): DspReal
 }

--- a/src/main/scala/dsptools/numbers/implicits/ImplicitsTop.scala
+++ b/src/main/scala/dsptools/numbers/implicits/ImplicitsTop.scala
@@ -3,11 +3,12 @@
 package dsptools.numbers
 
 import chisel3.experimental.FixedPoint
+import dsptools.numbers.chisel_types.IntervalImpl
 
 trait AllSyntax extends EqSyntax with PartialOrderSyntax with OrderSyntax with SignedSyntax with IsRealSyntax with IsIntegerSyntax with
   ConvertableToSyntax with ChiselConvertableFromSyntax with BinaryRepresentationSyntax with ContextualRingSyntax
 
-trait AllImpl extends UIntImpl with SIntImpl with FixedPointImpl with DspRealImpl with DspComplexImpl
+trait AllImpl extends UIntImpl with SIntImpl with IntervalImpl with FixedPointImpl with DspRealImpl with DspComplexImpl
 
 object implicits extends AllSyntax with AllImpl with spire.syntax.AllSyntax {
 }

--- a/src/main/scala/dsptools/tester/DspTester.scala
+++ b/src/main/scala/dsptools/tester/DspTester.scala
@@ -76,9 +76,9 @@ class DspTester[+T <: MultiIOModule](
 
   override def poke[T <: Element : Pokeable](signal: T, value: BigInt): Unit = {
     // bit-level poke is displayed as unsigned
-    val maskeValue = maskedBigInt(value, signal.widthOption.getOrElse(128))
+    val maskedValue = maskedBigInt(value, signal.widthOption.getOrElse(128))
     validRangeTest(signal, value)
-    if (!signal.isLit) backend.poke(signal, maskeValue, None)(logger, dispDsp, dispBase)
+    if (!signal.isLit) backend.poke(signal, maskedValue, None)(logger, dispDsp, dispBase)
     pokePrint(signal, value)
   }
 

--- a/src/test/scala/dsptools/numbers/IntervalSpec.scala
+++ b/src/test/scala/dsptools/numbers/IntervalSpec.scala
@@ -1,0 +1,221 @@
+// See LICENSE for license details.
+
+package dsptools.numbers
+
+//scalastyle:off magic.number
+
+import chisel3._
+import chisel3.experimental._
+import chisel3.internal.firrtl.IntervalRange
+import dsptools.DspTester
+import dsptools.numbers.implicits._
+import org.scalatest.{FreeSpec, Matchers}
+
+class IntervalRing1(val width: Int, val binaryPoint: Int) extends Module {
+  val range = IntervalRange(width.W, binaryPoint.BP)
+  val io = IO(new Bundle {
+    val in = Input(Interval(range))
+    val floor = Output(Interval(range))
+    val ceil = Output(Interval(range))
+    val isWhole = Output(Bool())
+    val round = Output(Interval(range))
+    val real = Output(DspReal())
+  })
+
+  io.floor := io.in.floor()
+  io.ceil := io.in.ceil().squeeze(io.ceil)
+  io.isWhole := io.in.isWhole()
+  io.round := io.in.round()
+  io.real := DspReal(0)
+}
+
+class IntervalRing1Tester(c: IntervalRing1) extends DspTester(c) {
+  val increment: Double = if(c.range.binaryPoint.get == 0) 1.0 else 1.0 / (1 << c.range.binaryPoint.get)
+  updatableDspVerbose.withValue(false) {
+    for(bd <- BigDecimal(-2.0) to BigDecimal(3.0) by increment) {
+      val i = bd.toDouble
+      poke(c.io.in, i)
+
+      expect(c.io.floor, breeze.numerics.floor(i), s"floor of $i should be ${breeze.numerics.floor(i)}")
+      expect(c.io.ceil, breeze.numerics.ceil(i), s"ceil of $i should be ${breeze.numerics.ceil(i)}")
+      expect(c.io.isWhole, breeze.numerics.floor(i) == i , s"isWhole of $i should be ${breeze.numerics.floor(i) == i}")
+      expect(c.io.round, breeze.numerics.round(i), s"round of $i should be ${breeze.numerics.round(i)}")
+      step(1)
+    }
+  }
+}
+
+/**
+  * Shift the inValue right and left, statically and dynamically.
+  * @note shiftRight has a constraint that shift amount must be less than width of inValue
+  * @param width width of shift target
+  * @param binaryPoint the binary point of the shift target
+  * @param fixedShiftSize how much to shift the target
+  */
+class IntervalShifter(val width: Int, val binaryPoint: Int, val fixedShiftSize: Int) extends Module {
+  val dynamicShifterWidth = 3
+
+  val io = IO(new Bundle {
+    val inValue = Input(Interval(IntervalRange(width.W, binaryPoint.BP)))
+    val dynamicShiftValue = Input(UInt(dynamicShifterWidth.W))
+    val shiftRightResult: Option[Interval] = if(fixedShiftSize < width) {
+      Some(Output(Interval(IntervalRange((width - fixedShiftSize).W, binaryPoint.BP))))
+    }
+    else {
+      None
+    }
+    val shiftLeftResult = Output(Interval(IntervalRange((width + fixedShiftSize).W, binaryPoint.BP)))
+    val dynamicShiftRightResult = Output(Interval(IntervalRange(width.W, binaryPoint.BP)))
+    val dynamicShiftLeftResult = Output(
+      Interval(IntervalRange((width + (1 << dynamicShifterWidth) - 1).W, binaryPoint.BP))
+    )
+  })
+
+  io.shiftLeftResult := io.inValue << fixedShiftSize
+  io.shiftRightResult.foreach { out =>
+    out := (io.inValue >> fixedShiftSize).asInstanceOf[Interval].squeeze(out)
+  }
+  io.dynamicShiftLeftResult := io.inValue << io.dynamicShiftValue
+  io.dynamicShiftRightResult := io.inValue >> io.dynamicShiftValue
+}
+
+object IntervalShifter extends App {
+  iotesters.Driver.executeFirrtlRepl(Array(), () => new IntervalShifter(8, 4, 3))
+}
+
+class IntervalShifterTest(c: IntervalShifter) extends DspTester(c) {
+  val increment: Double = 1.0 / (1 << c.binaryPoint)
+
+  def expectedValue(value: Double, left: Boolean, shift: Int): Double = {
+    val factor = 1 << c.binaryPoint
+    val x = value * factor
+    val y = x.toInt
+    val z = if(left) y << shift else y >> shift
+    val w = z.toDouble / factor
+    w
+  }
+
+  def truncate(value: Double): Double = {
+    val factor = 1 << c.binaryPoint
+    val x = value * factor
+    val y = x.toInt.toDouble
+    val z = y / factor
+    z
+  }
+  updatableDspVerbose.withValue(false) {
+
+    poke(c.io.dynamicShiftValue, 0)
+
+    val (minSIntValue, maxSIntValue) = firrtl_interpreter.extremaOfSIntOfWidth(c.width)
+
+    val minValue = minSIntValue.toDouble * increment
+    val maxValue = maxSIntValue.toDouble * increment
+
+    for(bd <- BigDecimal(minValue) to BigDecimal(maxValue) by increment) {
+      val value = bd.toDouble
+      poke(c.io.inValue, value)
+      expect(c.io.shiftLeftResult, expectedValue(value, left = true, c.fixedShiftSize),
+        s"shift left ${c.fixedShiftSize} of $value should be ${expectedValue(value, left = true, c.fixedShiftSize)}")
+      c.io.shiftRightResult.foreach { sro =>
+        expect(sro, expectedValue(value, left = false, c.fixedShiftSize),
+          s"shift right ${c.fixedShiftSize} of $value should be ${expectedValue(value, left = false, c.fixedShiftSize)}")
+      }
+
+      step(1)
+
+      for(dynamicShiftValue <- 0 until c.width) {
+        poke(c.io.dynamicShiftValue, dynamicShiftValue)
+        step(1)
+        expect(c.io.dynamicShiftLeftResult, expectedValue(value, left = true, dynamicShiftValue),
+          s"dynamic shift left $dynamicShiftValue of $value should " +
+            s"be ${expectedValue(value, left = true, dynamicShiftValue)}")
+        expect(c.io.dynamicShiftRightResult, expectedValue(value, left = false, dynamicShiftValue),
+          s"dynamic shift right $dynamicShiftValue of $value should" +
+            s"be ${expectedValue(value, left = false, dynamicShiftValue)}")
+      }
+    }
+
+  }
+}
+
+class IntervalBrokenShifter(n: Int) extends Module {
+  val io = IO(new Bundle {
+    val i = Input(Interval(range"[-256,256).4"))
+    val o = Output(Interval(range"[-256,256).4"))
+    val si = Input(SInt(8.W))
+    val so = Output(SInt(8.W))
+  })
+  io.o := io.i >> n
+  io.so := io.si >> n
+}
+
+class IntervalBrokenShifterTester(c: IntervalBrokenShifter) extends DspTester(c) {
+  updatableDspVerbose.withValue(false) {
+    poke(c.io.i, 1.5)
+    peek(c.io.o)
+    poke(c.io.si, 6)
+    peek(c.io.so)
+  }
+}
+
+class IntervalSpec extends FreeSpec with Matchers {
+  "Interval numbers should work properly for the following mathematical type functions" - {
+//    for (backendName <- Seq("verilator")) {
+//    for (backendName <- Seq("treadle")) {
+//    for (backendName <- Seq("firrtl")) {
+    for (backendName <- Seq("treadle", "verilator")) {
+      s"The ring family run with the $backendName simulator" - {
+        for (binaryPoint <- 0 to 4 by 2) {
+          s"should work, with binaryPoint $binaryPoint" in {
+            dsptools.Driver.execute(
+              () => new IntervalRing1(16, binaryPoint),
+              Array(
+                "--backend-name", backendName,
+                "--target-dir", s"test_run_dir/interval-ring-tests-$binaryPoint.BP"
+              )
+            ) { c =>
+              new IntervalRing1Tester(c)
+            } should be(true)
+          }
+        }
+      }
+
+      s"The shift family when run with the $backendName simulator" - {
+        val defaultWidth = 8
+        for {
+          binaryPoint <- Set(0, 1, 1) ++
+            (defaultWidth - 1 to defaultWidth + 1) ++
+            (defaultWidth * 2 - 1 to defaultWidth * 2 + 1)
+          fixedShiftSize <- Set(0, 1, 2) ++ (defaultWidth - 1 to defaultWidth + 1)
+        } {
+          s"should work with binary point $binaryPoint, with shift $fixedShiftSize " in {
+            dsptools.Driver.execute(
+              () => new IntervalShifter(width = 8, binaryPoint = binaryPoint, fixedShiftSize = fixedShiftSize),
+              Array(
+                "--backend-name", backendName,
+                "--target-dir", s"test_run_dir/interval-shift-test-$fixedShiftSize-$binaryPoint.BP"
+              )
+            ) { c =>
+              new IntervalShifterTest(c)
+            } should be(true)
+          }
+        }
+      }
+
+      //TODO: This error does not seem to be caught at this time.  Firrtl issue #450
+      s"shifting by too big a number causes error with $backendName" ignore {
+        for(shiftSize <- 8 to 10) {
+          dsptools.Driver.execute(
+            () => new IntervalBrokenShifter(n = shiftSize),
+            Array(
+              "--backend-name", backendName,
+              "--target-dir", s"test_run_dir/broken-shifter-$shiftSize"
+            )
+          ) { c =>
+            new IntervalBrokenShifterTester(c)
+          } should be(true)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Derived IntervalTypeClass from FixedPointTypeClass
- DspRealTypeClass needs asInterval
- FixedPoint, SInt and UInt type classes needs asInterval
- ChiselConvertableFrom get asInterval prototypes
- ImplicitsTop gets Interval references
- Fixed problem with poking negative fixed point and intervals into verilator backend