### PR TITLE
Signature of periphery bus has changed. Add (#203)

### DIFF
--- a/rocket/src/test/scala/amba/axi4/DMATests.scala
+++ b/rocket/src/test/scala/amba/axi4/DMATests.scala
@@ -227,7 +227,7 @@ class DmaSpec extends FlatSpec with Matchers {
         beatBytes = 16,
         blockBytes = 16 * 8,
         atomics = None,
-      )))
+      ), "periphery_bus"))
       pbus.toFixedWidthSlave(Some("dma")) {
         dma.mem.get := AXI4Buffer() := TLToAXI4() := TLFragmenter(8, 8 *8, holdFirstDeny = true)
       }


### PR DESCRIPTION
name that used to be hard-coded