### PR TITLE
Bump Rocketchip to June 2020

### DIFF
--- a/rocket/src/main/scala/amba/apb/Node.scala
+++ b/rocket/src/main/scala/amba/apb/Node.scala
@@ -42,7 +42,7 @@ case class BundleBridgeToAPBNode(masterParams: APBMasterPortParameters)(implicit
     dFn = { mp =>
       masterParams
     },
-    uFn = { slaveParams => BundleBridgeNull() }
+    uFn = { slaveParams => BundleBridgeParams(None) }
   )
 
 object BundleBridgeToAPBNode {

--- a/rocket/src/main/scala/amba/axi4/Node.scala
+++ b/rocket/src/main/scala/amba/axi4/Node.scala
@@ -42,7 +42,7 @@ case class BundleBridgeToAXI4Node(masterParams: AXI4MasterPortParameters)(implic
     dFn = { mp =>
       masterParams
     },
-    uFn = { slaveParams => BundleBridgeNull() }
+    uFn = { slaveParams => BundleBridgeParams(None) }
   )
 
 object BundleBridgeToAXI4Node {

--- a/rocket/src/main/scala/amba/axi4stream/Nodes.scala
+++ b/rocket/src/main/scala/amba/axi4stream/Nodes.scala
@@ -175,7 +175,7 @@ extends MixedAdapterNode(AXI4StreamBundleBridgeImp, AXI4StreamImp)(
   dFn = { mp =>
     masterParams
   },
-  uFn = { slaveParams => BundleBridgeNull() }// BundleBridgeParams(() => AXI4StreamBundle(AXI4StreamBundleParameters.joinEdge(masterParams, slaveParams)))}
+  uFn = { slaveParams => BundleBridgeParams(None) }// BundleBridgeParams(() => AXI4StreamBundle(AXI4StreamBundleParameters.joinEdge(masterParams, slaveParams)))}
 )
 
 object BundleBridgeToAXI4StreamNode {

--- a/rocket/src/main/scala/interrupts/Nodes.scala
+++ b/rocket/src/main/scala/interrupts/Nodes.scala
@@ -36,7 +36,7 @@ object IntToBundleBridge {
 case class BundleBridgeToIntNode(sourceParams: IntSourcePortParameters)
 (implicit valName: ValName) extends MixedAdapterNode(IntBundleBridgeImp, IntImp)(
   dFn = {sinkParams => sourceParams},
-  uFn = { slaveParams => BundleBridgeNull() }
+  uFn = { slaveParams => BundleBridgeParams(None) }
 )
 
 class BundleBridgeToInt(sourceParams: IntSourcePortParameters)(implicit p: Parameters)

--- a/rocket/src/main/scala/tl/Node.scala
+++ b/rocket/src/main/scala/tl/Node.scala
@@ -44,7 +44,7 @@ case class BundleBridgeToTLNode(clientParams: TLClientPortParameters)(implicit v
     dFn = { mp =>
       clientParams
     },
-    uFn = { slaveParams => BundleBridgeNull() }
+    uFn = { slaveParams => BundleBridgeParams(None) }
   )
 
 object BundleBridgeToTLNode {


### PR DESCRIPTION
Companion to https://github.com/ucb-bar/chipyard/pull/605

@grebe You may want to confirm if `BundleBridgeParams(None)` is equivalent to `BundleBridgeNull`, from these changes: https://github.com/chipsalliance/rocket-chip/pull/2497