### PR TITLE
Bump for RC Nov. / Chisel 3.4 / FIRRTL 1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ src/main/scala/dsptools/sandbox.sc
 test_run_dir/
 *.fir
 *.anno
+*.cmd
 ### XilinxISE template
 # intermediate build files
 *.bgn

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ env:
     INSTALL_DIR=$TRAVIS_BUILD_DIR/install
     VERILATOR_ROOT=$INSTALL_DIR
     PATH=$PATH:$VERILATOR_ROOT/bin:$TRAVIS_BUILD_DIR/utils/bin
-    CHISEL3=3.3-SNAPSHOT
-    CHISEL_TESTERS=1.4-SNAPSHOT
+    CHISEL_TESTERS=1.5.+
 
 install:
   # Install dependencies
@@ -23,5 +22,5 @@ install:
   - verilator --version
 
 script:
-  - set -o pipefail && sbt -Dchisel3Version=$CHISEL3 -Dchisel-iotestersVersion=$CHISEL_TESTERS test
+  - set -o pipefail && sbt -Dchisel-iotestersVersion=$CHISEL_TESTERS test
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,8 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "chisel-iotesters" -> "1.5-SNAPSHOT",
-  "rocketchip" -> "1.2-SNAPSHOT"
+  "chisel-iotesters" -> "1.5.+",
+  "rocketchip" -> "1.2.+"
 )
 
 name := "dsptools"
@@ -100,9 +100,9 @@ val dsptoolsSettings = Seq(
 // An explicit dependency on junit seems to alleviate this.
   libraryDependencies ++= Seq(
     "org.typelevel" %% "spire" % "0.16.2",
-    "org.scalanlp" %% "breeze" % "1.0",
+    "org.scalanlp" %% "breeze" % "1.1",
     "junit" % "junit" % "4.13" % "test",
-    "org.scalatest" %% "scalatest" % "3.2.2" % "test",
+    "org.scalatest" %% "scalatest" % "3.2.+" % "test",
     "org.scalacheck" %% "scalacheck" % "1.14.3" % "test"
   ),
 )

--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,7 @@ val dsptoolsSettings = Seq(
     "org.typelevel" %% "spire" % "0.16.2",
     "org.scalanlp" %% "breeze" % "1.0",
     "junit" % "junit" % "4.13" % "test",
-    "org.scalatest" %% "scalatest" % "3.0.8" % "test",
+    "org.scalatest" %% "scalatest" % "3.2.2" % "test",
     "org.scalacheck" %% "scalacheck" % "1.14.3" % "test"
   ),
 )

--- a/build.sbt
+++ b/build.sbt
@@ -92,9 +92,6 @@ val commonSettings = Seq(
 
 val dsptoolsSettings = Seq(
   name := "dsptools",
-  libraryDependencies ++= Seq("chisel-iotesters").map {
-    dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
-  },
 // sbt 1.2.6 fails with `Symbol 'term org.junit' is missing from the classpath`
 // when compiling tests under 2.11.12
 // An explicit dependency on junit seems to alleviate this.
@@ -123,13 +120,19 @@ publishArtifact in Test := false
 pomIncludeRepository := { x => false }
 
 // Don't add 'scm' elements if we have a git.remoteRepo definition.
-
+// TODO: FIXME: remove once `chisel-testers` 1.6.X is released with bumped `scalatest` deps
+// to enable add -Dsbt.sourcemode=true to SBT cmdline
+lazy val chiselIotestersRef = ProjectRef(uri("git://github.com/abejgonzalez/chisel-testers.git#5b9cc56"), "chisel-testers")
+lazy val chiselIotestersLib = Seq("chisel-iotesters").map {
+  dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
+}.head
 
 val dsptools = (project in file(".")).
   enablePlugins(BuildInfoPlugin).
   enablePlugins(ScalaUnidocPlugin).
   settings(commonSettings: _*).
-  settings(dsptoolsSettings: _*)
+  settings(dsptoolsSettings: _*).
+  sourceDependency(chiselIotestersRef, chiselIotestersLib)
 
 
 val `rocket-dsptools` = (project in file("rocket")).

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
+addSbtPlugin("com.eed3si9n" % "sbt-sriracha" % "0.1.0")

--- a/rocket/src/main/scala/amba/apb/Node.scala
+++ b/rocket/src/main/scala/amba/apb/Node.scala
@@ -44,7 +44,7 @@ case class BundleBridgeToAPBNode(masterParams: APBMasterPortParameters)(implicit
     dFn = { mp =>
       masterParams
     },
-    uFn = { slaveParams => BundleBridgeNull() }
+    uFn = { slaveParams => BundleBridgeParams(None) }
   )
 
 object BundleBridgeToAPBNode {

--- a/src/main/scala/dsptools/dspmath/Factorization.scala
+++ b/src/main/scala/dsptools/dspmath/Factorization.scala
@@ -2,7 +2,8 @@
 
 package dsptools.dspmath
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 case class RadPow(rad: Int, pow: Int) {
   /** `r ^ p` */
@@ -85,7 +86,7 @@ case class Factorization(supportedRadsUnsorted: Seq[Seq[Int]]) {
 
 }
 
-class FactorizationSpec extends FlatSpec with Matchers {
+class FactorizationSpec extends AnyFlatSpec with Matchers {
 
   val testSupportedRads = Seq(Seq(4, 2), Seq(3), Seq(5), Seq(7))
 

--- a/src/main/scala/examples/gainOffCorr.scala
+++ b/src/main/scala/examples/gainOffCorr.scala
@@ -5,7 +5,7 @@ package dsptools.examples
 import chisel3.core._
 import chisel3.{Bundle, Module}
 import dsptools.DspTester
-import org.scalatest.{Matchers, FlatSpec}
+
 import spire.algebra.Ring
 import spire.implicits._
 
@@ -22,8 +22,8 @@ class gainOffCorr[T<:Data:Ring](genIn: => T,genGain: => T,genOff: => T,genOut: =
        val offsetCorr = Input(Vec(numLanes, genOff))
        val outputVal = Output(Vec(numLanes, genOut))
     })
-   
-    val inputGainCorr = io.inputVal.zip(io.gainCorr).map{case (in, gain) => in*gain } 
+
+    val inputGainCorr = io.inputVal.zip(io.gainCorr).map{case (in, gain) => in*gain }
     io.outputVal := inputGainCorr.zip(io.offsetCorr).map{case (inGainCorr, offset) => inGainCorr + offset }
 }
 

--- a/src/test/scala/dsptools/BaseNSpec.scala
+++ b/src/test/scala/dsptools/BaseNSpec.scala
@@ -3,7 +3,8 @@
 package dsptools
 
 import chisel3._
-import org.scalatest.{Matchers, FreeSpec}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 //scalastyle:off magic.number
 
@@ -30,7 +31,7 @@ class BaseNCircuitTester(c: BaseNCircuit) extends DspTester(c) {
   }
 }
 
-class BaseNSpec extends FreeSpec with Matchers {
+class BaseNSpec extends AnyFreeSpec with Matchers {
   "baseN tester increments" ignore {
     chisel3.iotesters.Driver(() => new BaseNCircuit) { c =>
       new BaseNCircuitTester(c)

--- a/src/test/scala/dsptools/DspContextSpec.scala
+++ b/src/test/scala/dsptools/DspContextSpec.scala
@@ -4,11 +4,12 @@ package dsptools
 
 import chisel3._
 import dsptools.numbers._
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 //scalastyle:off magic.number
 
-class DspContextSpec extends FreeSpec with Matchers {
+class DspContextSpec extends AnyFreeSpec with Matchers {
   "Context handling should be unobtrusive and convenient" - {
     "There should be a default available at all times" in {
       DspContext.current.binaryPoint should be (DspContext.defaultBinaryPoint)

--- a/src/test/scala/dsptools/DspTesterSpec.scala
+++ b/src/test/scala/dsptools/DspTesterSpec.scala
@@ -3,14 +3,15 @@
 package dsptools
 
 import DspTesterUtilities._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.math.{pow, abs}
 
 class DspTesterSpec {
 
 }
 
-class DspTesterUtilitiesSpec extends FlatSpec with Matchers {
+class DspTesterUtilitiesSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Tester Converters"
 

--- a/src/test/scala/dsptools/LoggingSpec.scala
+++ b/src/test/scala/dsptools/LoggingSpec.scala
@@ -4,7 +4,8 @@ package dsptools
 
 import chisel3._
 import logger.{LazyLogging, LogLevel, Logger}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 class DutWithLogging extends Module with LazyLogging {
   val io = IO(new Bundle {})
@@ -18,7 +19,7 @@ class DutWithLogging extends Module with LazyLogging {
 
 class DutWithLoggingTester(c: DutWithLogging) extends DspTester(c)
 
-class LoggingSpec extends FreeSpec with Matchers {
+class LoggingSpec extends AnyFreeSpec with Matchers {
   "logging can be emitted during hardware generation" - {
     "level defaults to warn" in {
       Logger.makeScope() {

--- a/src/test/scala/dsptools/ShiftRegisterDelaySpec.scala
+++ b/src/test/scala/dsptools/ShiftRegisterDelaySpec.scala
@@ -5,7 +5,8 @@ package dsptools
 import chisel3._
 import chisel3.core.FixedPoint
 import dsptools.numbers._
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.mutable
 
@@ -112,7 +113,7 @@ class CeilTruncateTester(c: CeilTruncateCircuitWithDelays) extends DspTester(c) 
   }
 }
 
-class ShiftRegisterDelaySpec extends FreeSpec with Matchers {
+class ShiftRegisterDelaySpec extends AnyFreeSpec with Matchers {
   "ceil delay should be consistent between dsp real and fixed point" in {
     dsptools.Driver.execute(
       () => new CeilTruncateCircuitWithDelays(2),

--- a/src/test/scala/dsptools/numbers/AbsSpec.scala
+++ b/src/test/scala/dsptools/numbers/AbsSpec.scala
@@ -5,9 +5,10 @@ package dsptools.numbers
 import chisel3._
 import chisel3.experimental._
 import dsptools.{DspContext, DspTester, Grow, Wrap}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class AbsSpec extends FreeSpec with Matchers {
+class AbsSpec extends AnyFreeSpec with Matchers {
   "absolute value should work for all types" - {
     "abs should be obvious when not at extreme negative" - {
       "but returns a negative number for extreme value at max negative for SInt and FixedPoint" - {

--- a/src/test/scala/dsptools/numbers/BaseNSpec.scala
+++ b/src/test/scala/dsptools/numbers/BaseNSpec.scala
@@ -3,9 +3,10 @@
 package dsptools.numbers
 
 import dsptools.numbers.representations.BaseN
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class BaseNSpec extends FlatSpec with Matchers {
+class BaseNSpec extends AnyFlatSpec with Matchers {
   behavior of "BaseN"
   it should "properly convert a decimal into BaseN" in {
     // n in decimal, rad = radix, res = expected representation in base rad

--- a/src/test/scala/dsptools/numbers/FixedPointSpec.scala
+++ b/src/test/scala/dsptools/numbers/FixedPointSpec.scala
@@ -10,7 +10,8 @@ import chisel3.iotesters.ChiselPropSpec
 import chisel3.testers.BasicTester
 import dsptools.DspTester
 import dsptools.numbers.implicits._
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 class FixedRing1(val width: Int, val binaryPoint: Int) extends Module {
   val io = IO(new Bundle {
@@ -154,7 +155,7 @@ class BrokenShifterTester(c: BrokenShifter) extends DspTester(c) {
   }
 }
 
-class FixedPointSpec extends FreeSpec with Matchers {
+class FixedPointSpec extends AnyFreeSpec with Matchers {
   "FixedPoint numbers should work properly for the following mathematical type functions" - {
 //    for (backendName <- Seq("verilator")) {
     for (backendName <- Seq("firrtl", "verilator")) {
@@ -219,11 +220,11 @@ class FixedPointChiselSpec extends ChiselPropSpec {
   property("asReal shold work") {
     assertTesterPasses { new BasicTester {
       val x = FixedPoint.fromDouble(13.5, 16.W, 4.BP)
- 
+
       val y = x.asReal
- 
+
       chisel3.assert(y === DspReal(13.5))
- 
+
       stop()
     }}
   }

--- a/src/test/scala/dsptools/numbers/FixedPrecisionChangerSpec.scala
+++ b/src/test/scala/dsptools/numbers/FixedPrecisionChangerSpec.scala
@@ -5,7 +5,8 @@ package dsptools.numbers
 import chisel3._
 import chisel3.experimental.FixedPoint
 import dsptools.DspTester
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 //scalastyle:off magic.number
 
@@ -43,7 +44,7 @@ class RemoveMantissaTester(c: RemoveMantissa, inValue: Double, outValue: Double)
   expect(c.io.out, outValue, s"got ${peek(c.io.out)} should have $outValue")
 }
 
-class FixedPrecisionChangerSpec extends FreeSpec with Matchers {
+class FixedPrecisionChangerSpec extends AnyFreeSpec with Matchers {
   "assignment of numbers with differing binary points seems to work as I would expect" - {
     "here we assign to a F8.1 from a F8.3" in {
       dsptools.Driver.execute(() => new FixedPrecisionChanger(8, 3, 8, 1)) { c =>

--- a/src/test/scala/dsptools/numbers/IntervalSpec.scala
+++ b/src/test/scala/dsptools/numbers/IntervalSpec.scala
@@ -9,7 +9,8 @@ import chisel3.experimental._
 import chisel3.internal.firrtl.IntervalRange
 import dsptools.DspTester
 import dsptools.numbers.implicits._
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 class IntervalRing1(val width: Int, val binaryPoint: Int) extends Module {
   val range = IntervalRange(width.W, binaryPoint.BP)
@@ -158,7 +159,7 @@ class IntervalBrokenShifterTester(c: IntervalBrokenShifter) extends DspTester(c)
   }
 }
 
-class IntervalSpec extends FreeSpec with Matchers {
+class IntervalSpec extends AnyFreeSpec with Matchers {
   "Interval numbers should work properly for the following mathematical type functions" - {
 //    for (backendName <- Seq("verilator")) {
 //    for (backendName <- Seq("treadle")) {

--- a/src/test/scala/dsptools/numbers/LnSpec.scala
+++ b/src/test/scala/dsptools/numbers/LnSpec.scala
@@ -7,7 +7,8 @@ import chisel3.util._
 import chisel3.testers.BasicTester
 import chisel3.iotesters.{ChiselFlatSpec, PeekPokeTester, TesterOptionsManager}
 import dsptools.{DspTester, ReplOptionsManager}
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 class LnModule extends Module {
   val io = IO(new Bundle {
@@ -24,7 +25,7 @@ class LnTester(c: LnModule) extends DspTester(c) {
   println(s"poked 1.0 got $x expected ${math.log(11.0)}")
 
 }
-class LnSpec extends FreeSpec {
+class LnSpec extends AnyFreeSpec {
   "ln should work" in {
     dsptools.Driver.execute(() => new LnModule) { c =>
       new LnTester(c)

--- a/src/test/scala/dsptools/numbers/NumbersSpec.scala
+++ b/src/test/scala/dsptools/numbers/NumbersSpec.scala
@@ -6,13 +6,14 @@ import chisel3._
 import dsptools._
 import chisel3.experimental.FixedPoint
 import dsptools.numbers.implicits._
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * This will attempt to follow the dsptools.numbers.README.md file as close as possible.
   */
 //scalastyle:off magic.number
-class NumbersSpec extends FreeSpec with Matchers {
+class NumbersSpec extends AnyFreeSpec with Matchers {
   def f(w: Int, b: Int): FixedPoint = FixedPoint(w.W, b.BP)
   def u(w: Int): UInt = UInt(w.W)
   def s(w: Int): SInt = SInt(w.W)

--- a/src/test/scala/dsptools/numbers/OverflowSpec.scala
+++ b/src/test/scala/dsptools/numbers/OverflowSpec.scala
@@ -2,8 +2,9 @@
 
 package dsptools.numbers
 
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class OverflowSpec extends FreeSpec with Matchers {
+class OverflowSpec extends AnyFreeSpec with Matchers {
 
 }

--- a/src/test/scala/dsptools/numbers/ParameterizedOpSpec.scala
+++ b/src/test/scala/dsptools/numbers/ParameterizedOpSpec.scala
@@ -7,7 +7,8 @@ import chisel3._
 import chisel3.experimental.FixedPoint
 import chisel3.iotesters.TesterOptionsManager
 import dsptools.DspTester
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import dsptools.numbers._
 import dsptools._
 
@@ -62,7 +63,7 @@ class ParameterizedOpTester[T<:Data:Ring](c: ParameterizedNumberOperation[T]) ex
   }
 }
 
-class ParameterizedOpSpecification extends FreeSpec with Matchers {
+class ParameterizedOpSpecification extends AnyFreeSpec with Matchers {
   """
   The ParameterizedNumericOperation demonstrates a Module that can be instantiated to
   handle different numeric types and different numerical operations
@@ -124,7 +125,7 @@ class ComplexOpTester[T<:DspComplex[_]](c: ParameterizedNumberOperation[T]) exte
   }
 }
 
-class ComplexOpSpecification extends FreeSpec with Matchers {
+class ComplexOpSpecification extends AnyFreeSpec with Matchers {
   """
   The ParameterizedNumericOperation demonstrates a Module that can be instantiated to
   handle different numeric types and different numerical operations

--- a/src/test/scala/dsptools/numbers/SaturateSpec.scala
+++ b/src/test/scala/dsptools/numbers/SaturateSpec.scala
@@ -5,7 +5,8 @@ package dsptools.numbers.rounding
 import chisel3._
 import chisel3.experimental.FixedPoint
 import chisel3.iotesters._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class SaturateUIntMod(val add: Boolean) extends MultiIOModule {
   val a = IO(Input(UInt(8.W)))
@@ -148,7 +149,7 @@ class SaturateFixedPointTester(dut: SaturateFixedPointMod) extends PeekPokeTeste
   }
 }
 
-class SaturateSpec extends FlatSpec with Matchers {
+class SaturateSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Saturating add"
 

--- a/src/test/scala/dsptools/numbers/TypeclassSpec.scala
+++ b/src/test/scala/dsptools/numbers/TypeclassSpec.scala
@@ -7,7 +7,8 @@ import chisel3.experimental.FixedPoint
 import chisel3.iotesters._
 import dsptools._
 import dsptools.numbers._
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 /*
  * These tests mostly exist to ensure that expressions of the form
@@ -98,7 +99,7 @@ extends DspTester(dut) with FuncTester[DspReal, Double] {
   def myExpect(port: DspReal, value: Double) = expect(port, value)
 }
 
-class TypeclassSpec extends FreeSpec with Matchers {
+class TypeclassSpec extends AnyFreeSpec with Matchers {
   "Ring[T].func() should work" in {
     dsptools.Driver.execute( () => new RingModule(SInt(10.W)) ) { c =>
       new SIntFuncTester(c, Seq(2, -3), Seq(2, -3))

--- a/src/test/scala/examples/CaseClassBundleSpec.scala
+++ b/src/test/scala/examples/CaseClassBundleSpec.scala
@@ -4,7 +4,8 @@ package examples
 
 import chisel3._
 import chisel3.iotesters.PeekPokeTester
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 //scalastyle:off magic.number
 
@@ -38,7 +39,7 @@ class SimpleCaseClassBundleTester(c: SimpleCaseClassModule) extends PeekPokeTest
   expect(c.io.out.underlying, 7)
 }
 
-class SimpleCaseClassBundleSpec extends FlatSpec with Matchers {
+class SimpleCaseClassBundleSpec extends AnyFlatSpec with Matchers {
   behavior of "SimpleCaseClassBundle"
 
   it should "push number through with one step delay" in {

--- a/src/test/scala/examples/ComplexAdderSpec.scala
+++ b/src/test/scala/examples/ComplexAdderSpec.scala
@@ -7,7 +7,8 @@ import chisel3.iotesters.{Backend}
 import chisel3.{Bundle, Module}
 import dsptools.{DspContext, DspTester}
 import dsptools.numbers._
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import spire.algebra.Ring
 
 //scalastyle:off magic.number
@@ -45,7 +46,7 @@ class SimpleComplexAdderTester(c: SimpleComplexAdder) extends DspTester(c) {
     println(s"SimpleComplexAdder: $i * $j should make $expected got ${peek(c.io.c.real)}")
   }
 }
-class SimpleComplexAdderSpec extends FlatSpec with Matchers {
+class SimpleComplexAdderSpec extends AnyFlatSpec with Matchers {
   behavior of "SimpleComplexAdder"
 
   it should "add complex numbers excellently" in {

--- a/src/test/scala/examples/ParameterizedAdderSpec.scala
+++ b/src/test/scala/examples/ParameterizedAdderSpec.scala
@@ -6,7 +6,8 @@ import chisel3._
 import chisel3.experimental.FixedPoint
 import dsptools.DspTester
 import dsptools.numbers._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 //scalastyle:off magic.number
 
@@ -41,7 +42,7 @@ class ParameterizedAdderTester[T<:Data:Ring](c: ParameterizedAdder[T]) extends D
   }
 }
 
-class ParameterizedAdderSpec extends FlatSpec with Matchers {
+class ParameterizedAdderSpec extends AnyFlatSpec with Matchers {
 
   behavior of "parameterized adder circuit on blackbox real"
 

--- a/src/test/scala/examples/ParameterizedSaturatingAdder.scala
+++ b/src/test/scala/examples/ParameterizedSaturatingAdder.scala
@@ -5,7 +5,8 @@ package examples
 import chisel3._
 import dsptools.{DspContext, DspTester, Saturate}
 import dsptools.numbers._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class ParameterizedSaturatingAdder[T <: Data:Integer](gen:() => T) extends Module {
   val io = IO(new Bundle {
@@ -60,7 +61,7 @@ class ParameterizedSaturatingAdderTester[T<:Data:Integer](c: ParameterizedSatura
   }
 }
 
-class ParameterizedSaturatingAdderSpec extends FlatSpec with Matchers {
+class ParameterizedSaturatingAdderSpec extends AnyFlatSpec with Matchers {
   behavior of "parameterized saturating adder circuit on SInt"
 
   ignore should "allow registers to be declared that infer widths" in {

--- a/src/test/scala/examples/RealAdderSpec.scala
+++ b/src/test/scala/examples/RealAdderSpec.scala
@@ -5,7 +5,8 @@ package examples
 import chisel3._
 import dsptools.{ReplOptionsManager, DspTester}
 import dsptools.numbers.DspReal
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class RealAdder extends Module {
   val io = IO(new Bundle {
@@ -44,7 +45,7 @@ class RealAdderTester(c: RealAdder) extends DspTester(c) {
 }
 
 
-class RealAdderSpec extends FlatSpec with Matchers {
+class RealAdderSpec extends AnyFlatSpec with Matchers {
   behavior of "adder circuit on blackbox real"
 
   it should "allow registers to be declared that infer widths" in {

--- a/src/test/scala/examples/SimpleAdderSpec.scala
+++ b/src/test/scala/examples/SimpleAdderSpec.scala
@@ -5,7 +5,8 @@ package examples
 import chisel3.core._
 import chisel3.{Bundle, Module}
 import dsptools.DspTester
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class SimpleAdder extends Module {
   val io = IO(new Bundle {
@@ -36,7 +37,7 @@ class SimpleAdderTester(c: SimpleAdder) extends DspTester(c) {
     println(s"SimpleAdder: $i + $j should make $expected got ${peek(c.io.c)}")
   }
 }
-class SimpleAdderSpec extends FlatSpec with Matchers {
+class SimpleAdderSpec extends AnyFlatSpec with Matchers {
   behavior of "SimpleAdder"
 
   it should "add to numbers excellently" in {

--- a/src/test/scala/examples/SimpleDspModuleSpec.scala
+++ b/src/test/scala/examples/SimpleDspModuleSpec.scala
@@ -15,7 +15,8 @@ import dsptools.{DspTester, DspTesterOptionsManager, DspTesterOptions}
 // Allows you to modify default Chisel tester behavior (note that DspTester is a special version of Chisel tester)
 import iotesters.TesterOptions
 // Scala unit testing style
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 // IO Bundle. Note that when you parameterize the bundle, you MUST override cloneType.
 // This also creates x, y, z inputs/outputs (direction must be specified at some IO hierarchy level)
@@ -33,9 +34,9 @@ class SimpleDspModule[T <: Data:RealBits](gen: T, val addPipes: Int) extends Mod
   val io = IO(new SimpleDspIo(gen))
   // Output will be current x + y addPipes clk cycles later
   // Note that this relies on the fact that type classes have a special + that
-  // add addPipes # of ShiftRegister after the sum. If you don't wrap the sum in 
+  // add addPipes # of ShiftRegister after the sum. If you don't wrap the sum in
   // DspContext.withNumAddPipes(addPipes), the default # of addPipes is used.
-  DspContext.withNumAddPipes(addPipes) { 
+  DspContext.withNumAddPipes(addPipes) {
     io.z := io.x context_+ io.y
   }
 }
@@ -49,7 +50,7 @@ class SimpleDspModuleTester[T <: Data:RealBits](c: SimpleDspModule[T]) extends D
     // Feed in to the x, y inputs
     poke(c.io.x, in)
     // Locally (just for the stuff in {}) change console print properties
-    // so that this second peek isn't displayed on the console 
+    // so that this second peek isn't displayed on the console
     // (since the input value is the same as the first peek)
     updatableDspVerbose.withValue(false) {
       poke(c.io.y, in)
@@ -65,8 +66,8 @@ class SimpleDspModuleTester[T <: Data:RealBits](c: SimpleDspModule[T]) extends D
 }
 
 // Scala style testing
-class SimpleDspModuleSpec extends FlatSpec with Matchers {
-  
+class SimpleDspModuleSpec extends AnyFlatSpec with Matchers {
+
   // If you don't want to use default tester options, you need to create your own DspTesterOptionsManager
   val testOptions = new DspTesterOptionsManager {
     // Customizing Dsp-specific tester features (unspecified options remain @ default values)
@@ -83,7 +84,7 @@ class SimpleDspModuleSpec extends FlatSpec with Matchers {
         // print out BigInt or base n versions of peeks/pokes -- rather than the proper decimal representation)
         isVerbose = false,
         // Default backend uses FirrtlInterpreter. If you want to simulate with the generated Verilog,
-        // you need to switch the backend to Verilator. Note that tests currently need to be dumped in 
+        // you need to switch the backend to Verilator. Note that tests currently need to be dumped in
         // different output directories with Verilator; otherwise you run into weird concurrency issues (bug!)...
         backendName = "verilator")
     // Override default output directory while maintaining other default settings

--- a/src/test/scala/examples/StreamingAutocorrelatorSpec.scala
+++ b/src/test/scala/examples/StreamingAutocorrelatorSpec.scala
@@ -7,7 +7,8 @@ package examples
 import chisel3._
 import chisel3.iotesters.PeekPokeTester
 import dsptools.numbers.implicits._
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import spire.algebra.{Ring, Field}
 
@@ -22,7 +23,7 @@ class StreamingAutocorrelatorTester(c: StreamingAutocorrelator[SInt])
   }
 }
 
-class StreamingAutocorrelatorSpec extends FlatSpec with Matchers {
+class StreamingAutocorrelatorSpec extends AnyFlatSpec with Matchers {
   "StreamingAutocorrelatorFIR" should "compute a running average like thing" in {
     val taps = Seq.tabulate(3) { x => x.S}
     //implicit val DefaultDspContext = DspContext()

--- a/src/test/scala/examples/TransposedStreamFIRSpec.scala
+++ b/src/test/scala/examples/TransposedStreamFIRSpec.scala
@@ -8,7 +8,8 @@ import chisel3._
 import chisel3.iotesters.{PeekPokeTester, TesterOptions}
 import dsptools.numbers.implicits._
 import dsptools.{DspContext, Grow}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import dsptools.examples.{ConstantTapTransposedStreamingFIR, TransposedStreamingFIR}
 import spire.algebra.{Field, Ring}
 
@@ -57,7 +58,7 @@ class TransposedStreamingTester(c: TransposedStreamingFIR[SInt])
   }
 }
 
-class TransposedStreamFIRSpec extends FlatSpec with Matchers {
+class TransposedStreamFIRSpec extends AnyFlatSpec with Matchers {
   "ConstantTapTransposedStreamingFIR" should "compute a running average like thing" in {
     val taps = 0 until 3
 


### PR DESCRIPTION
Related PR: https://github.com/ucb-bar/chipyard/pull/719

Bump for RC Nov. / Chisel 3.4 / FIRRTL 1.4
- Bump `scalatest` to 3.2.2
- Small cleanup
- Remove unused BundleBridgeNull