### PR TITLE
somehow dsptools lost the scm information

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,10 @@ val commonSettings = Seq(
       <distribution>repo</distribution>
     </license>
   </licenses>
+    <scm>
+      <url>https://github.com/ucb-bar/dsptools.git</url>
+      <connection>scm:git:github.com/ucb-bar/dsptools.git</connection>
+    </scm>
   <developers>
     <developer>
       <id>grebe</id>


### PR DESCRIPTION
necessary for sonatype to allow it to be deployed.
This adds it back in