### PR TITLE
Ignore tests that put literals in Bundle types

### DIFF
--- a/src/test/scala/dsptools/VerboseDspTesterSpec/SimpleTBwGenTypeOption.scala
+++ b/src/test/scala/dsptools/VerboseDspTesterSpec/SimpleTBwGenTypeOption.scala
@@ -366,7 +366,7 @@ class SimpleTBSpec extends AnyFlatSpec with Matchers {
 
   behavior of "simple module lits"
 
-  it should "properly read lits with gen = sint (reals rounded) and expect tolerance set to 1 bit" in {
+  ignore should "properly read lits with gen = sint (reals rounded) and expect tolerance set to 1 bit" in {
     val opt = new DspTesterOptionsManager {
       dspTesterOptions = optionsPass.dspTesterOptions
       testerOptions = optionsPass.testerOptions
@@ -377,7 +377,7 @@ class SimpleTBSpec extends AnyFlatSpec with Matchers {
     } should be (true)
   }
 
-  it should "properly read lits with gen = fixed and expect tolerance set to 1 bit " +
+  ignore should "properly read lits with gen = fixed and expect tolerance set to 1 bit " +
       "(even with finite fractional bits)" in {
     val opt = new DspTesterOptionsManager {
       dspTesterOptions = optionsPass.dspTesterOptions
@@ -389,7 +389,7 @@ class SimpleTBSpec extends AnyFlatSpec with Matchers {
     } should be (true)
   }
 
-  it should "*fail* to read all lits with gen = fixed when expect tolerance is set to 0 bits " +
+  ignore should "*fail* to read all lits with gen = fixed when expect tolerance is set to 0 bits " +
       "(due to not having enough fractional bits to represent #s)" in {
     val opt = new DspTesterOptionsManager {
       dspTesterOptions = optionsFail.dspTesterOptions


### PR DESCRIPTION
This was never intended to be supported in Chisel3 and is more
explicitly banned in Chisel v3.5.0-RC1. These tests can become compliant
with the stricter API by using Bundle literals rather than Bundles with
literals for fields.

The check these are failing was introduced in https://github.com/chipsalliance/chisel3/pull/2046.

I think these tests should be fixed but I don't want to block the release candidate on them.

Annoyingly, these are really hard to debug because the stack trace trimming is hiding everything which is a separate issue that we should address, here's a useful diff to apply to help when debugging this:
```diff
diff --git a/src/main/scala/dsptools/Driver.scala b/src/main/scala/dsptools/Driver.scala
index e776362..4ae6da2 100644
--- a/src/main/scala/dsptools/Driver.scala
+++ b/src/main/scala/dsptools/Driver.scala
@@ -31,6 +31,9 @@ object Driver {
       optionsManager.treadleOptions = optionsManager.treadleOptions.copy(
         blackBoxFactories = optionsManager.treadleOptions.blackBoxFactories :+ new TreadleDspRealFactory
       )
+      optionsManager.chiselOptions = optionsManager.chiselOptions.copy(
+        printFullStackTrace = true
+      )
       iotesters.Driver.execute(dutGenerator, optionsManager)(testerGen)
     }
 
```