### PR TITLE
Fix RegInit bug when using DspComplex initializer

### DIFF
--- a/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
+++ b/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chisel3.experimental.{FixedPoint, Interval}
 import dsptools.DspException
 import breeze.math.Complex
+import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor
 
 object DspComplex {
 
@@ -18,9 +19,13 @@ object DspComplex {
   // In reality, real and imag should have the same type, so should be using single argument
   // apply if you aren't trying t create a Lit
   def apply[T <: Data:Ring](real: T, imag: T): DspComplex[T] = {
-    val newReal = if (real.isLit()) real else real.cloneType
-    val newImag = if (imag.isLit()) imag else imag.cloneType
-    new DspComplex(newReal, newImag)
+    if(real.isLit() && imag.isLit()) {
+      new DspComplex(real, imag).Lit(_.real -> real, _.imag -> imag)
+    } else {
+      val newReal = if (real.isLit()) real else real.cloneType
+      val newImag = if (imag.isLit()) imag else imag.cloneType
+      new DspComplex(newReal, newImag)
+    }
   }
 
   // Needed for assigning to results of operations; should not use in user code for making wires
@@ -34,7 +39,7 @@ object DspComplex {
 
   // Constant j
   // TODO(Paul): this call to wire() should be removed when chisel has literal bundles
-  def j[T <: Data:Ring] : DspComplex[T] = wire(Ring[T].zero, Ring[T].one)
+  def j[T <: Data:Ring] : DspComplex[T] = DspComplex(Ring[T].zero, Ring[T].one)
 
   // Creates a DspComplex literal of type DspComplex[T] from a Breeze Complex
   // Note: when T is FixedPoint, the # of fractional bits is determined via DspContext

--- a/src/test/scala/dsptools/numbers/DspComplexSpec.scala
+++ b/src/test/scala/dsptools/numbers/DspComplexSpec.scala
@@ -53,7 +53,7 @@ class SIntTester extends BasicTester {
 
   assert( x === xcopy )
 
-  val y = DspComplex.wire((-4).S, (-1).S)
+  val y = DspComplex((-4).S, (-1).S)
 
   assert ( y.real === (-4).S)
   assert (y.imag === (-1).S)


### PR DESCRIPTION
Fix RegInit bug when using DspComplex initializer

- Problem reported here: https://gitter.im/freechipsproject/chisel3?at=615c64087db1e3753e2346f5
- This fix makes DspComplex.apply create a Bundle literal when arguments are literals
- Change creation of J to return a bundle lit
- Add test for reported scenario