### PR TITLE
3.5 cleanup

### DIFF
--- a/src/main/scala/dsptools/Driver.scala
+++ b/src/main/scala/dsptools/Driver.scala
@@ -16,7 +16,7 @@ object Driver {
   private val optionsManagerVar = new DynamicVariable[Option[DspTesterOptionsManager]](None)
   def optionsManager = optionsManagerVar.value.getOrElse(new DspTesterOptionsManager)
 
-  def execute[T <: MultiIOModule](dutGenerator: () => T,
+  def execute[T <: Module](dutGenerator: () => T,
       optionsManager: TesterOptionsManager)(testerGen: T => PeekPokeTester[T]): Boolean = {
 
     val om = optionsManager match {
@@ -36,7 +36,7 @@ object Driver {
 
   }
 
-  def execute[T <: MultiIOModule](dutGenerator: () => T,
+  def execute[T <: Module](dutGenerator: () => T,
       args: Array[String] = Array.empty)(testerGen: T => PeekPokeTester[T]): Boolean = {
 
     val optionsManager = new DspTesterOptionsManager {
@@ -56,7 +56,7 @@ object Driver {
     }
   }
 
-  def executeFirrtlRepl[T <: MultiIOModule](dutGenerator: () => T,
+  def executeFirrtlRepl[T <: Module](dutGenerator: () => T,
       optionsManager: ReplOptionsManager = new ReplOptionsManager): Boolean = {
 
     optionsManager.chiselOptions = optionsManager.chiselOptions.copy(runFirrtlCompiler = false)

--- a/src/main/scala/dsptools/Driver.scala
+++ b/src/main/scala/dsptools/Driver.scala
@@ -68,6 +68,7 @@ object Driver {
       blackBoxFactories = optionsManager.treadleOptions.blackBoxFactories :+ new TreadleDspRealFactory
     )
 
+
     logger.Logger.makeScope(optionsManager) {
       val chiselResult: ChiselExecutionResult = iotesters.DriverCompatibility.execute(optionsManager, dutGenerator)
       chiselResult match {

--- a/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
+++ b/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
@@ -11,7 +11,7 @@ import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor
 object DspComplex {
 
   def apply[T <: Data:Ring](gen: T): DspComplex[T] = {
-    if (gen.isLit()) throw DspException("Cannot use Lit in single argument DspComplex.apply")
+    if (gen.isLit) throw DspException("Cannot use Lit in single argument DspComplex.apply")
     apply(gen, gen)
   }
 
@@ -22,8 +22,8 @@ object DspComplex {
     if(real.isLit && imag.isLit) {
       new DspComplex(real, imag).Lit(_.real -> real, _.imag -> imag)
     } else {
-      val newReal = if (real.isLit()) real else real.cloneType
-      val newImag = if (imag.isLit()) imag else imag.cloneType
+      val newReal = if (real.isLit) real else real.cloneType
+      val newImag = if (imag.isLit) imag else imag.cloneType
       new DspComplex(newReal, newImag)
     }
   }

--- a/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
+++ b/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
@@ -19,7 +19,7 @@ object DspComplex {
   // In reality, real and imag should have the same type, so should be using single argument
   // apply if you aren't trying t create a Lit
   def apply[T <: Data:Ring](real: T, imag: T): DspComplex[T] = {
-    if(real.isLit() && imag.isLit()) {
+    if(real.isLit && imag.isLit) {
       new DspComplex(real, imag).Lit(_.real -> real, _.imag -> imag)
     } else {
       val newReal = if (real.isLit()) real else real.cloneType
@@ -38,7 +38,6 @@ object DspComplex {
   }
 
   // Constant j
-  // TODO(Paul): this call to wire() should be removed when chisel has literal bundles
   def j[T <: Data:Ring] : DspComplex[T] = DspComplex(Ring[T].zero, Ring[T].one)
 
   // Creates a DspComplex literal of type DspComplex[T] from a Breeze Complex

--- a/src/main/scala/dsptools/numbers/rounding/Saturate.scala
+++ b/src/main/scala/dsptools/numbers/rounding/Saturate.scala
@@ -5,9 +5,10 @@ package dsptools.numbers.rounding
 import chisel3._
 import chisel3.experimental.{ChiselAnnotation, FixedPoint, RunFirrtlTransform, annotate, requireIsHardware}
 import chisel3.stage.ChiselStage
-import firrtl.{CircuitForm, CircuitState, HighForm, MidForm, Transform}
+import firrtl.{CircuitState, DependencyAPIMigration, Transform}
 import firrtl.annotations.{ModuleName, SingleTargetAnnotation, Target}
-import firrtl.ir.{Block, DefModule, FixedType, IntWidth, SIntType, UIntType, Module => FModule}
+import firrtl.ir.{DefModule, FixedType, IntWidth, SIntType, UIntType, Module => FModule}
+import firrtl.stage.TransformManager.TransformDependency
 
 import scala.collection.immutable.HashMap
 import scala.language.existentials
@@ -200,9 +201,8 @@ object Saturate {
   }
 }
 
-class SaturateTransform extends Transform {
-  def inputForm: CircuitForm = MidForm
-  def outputForm: CircuitForm = HighForm
+class SaturateTransform extends Transform with DependencyAPIMigration{
+  override def prerequisites: Seq[TransformDependency] = firrtl.stage.Forms.MidForm
 
   private def replaceMod(m: FModule, anno: SaturateAnnotation): FModule = {
     val aTpe = m.ports.find(_.name == "a").map(_.tpe).getOrElse(throw new Exception("a not found"))

--- a/src/main/scala/dsptools/numbers/rounding/Saturate.scala
+++ b/src/main/scala/dsptools/numbers/rounding/Saturate.scala
@@ -25,7 +25,7 @@ case class SaturateChiselAnnotation(target: SaturateDummyModule[_ <: Data], op: 
   def transformClass: Class[SaturateTransform] = classOf[SaturateTransform]
 }
 
-trait SaturateModule[T <: Data] extends MultiIOModule {
+trait SaturateModule[T <: Data] extends Module {
   val a: T
   val b: T
   val c: T

--- a/src/main/scala/dsptools/tester/DspTester.scala
+++ b/src/main/scala/dsptools/tester/DspTester.scala
@@ -98,7 +98,7 @@ class DspTester[+T <: Module](
       if (!signal.isLit) {
         backend.peek(signal, None)(logger, dispDsp, dispBase)
       } else {
-        val litVal = signal.litValue()
+        val litVal = signal.litValue
         if (dispDsp) {
           logger info s"  PEEK ${getName(signal)} -> ${TestersCompatibility.bigIntToStr(litVal, dispBase)}"
         }

--- a/src/main/scala/dsptools/tester/DspTester.scala
+++ b/src/main/scala/dsptools/tester/DspTester.scala
@@ -16,7 +16,7 @@ import scala.util.DynamicVariable
 import chisel3.iotesters.TestersCompatibility
 
 //scalastyle:off number.of.methods cyclomatic.complexity
-class DspTester[+T <: MultiIOModule](
+class DspTester[+T <: Module](
     dut: T,
     base: Int = 16,
     logFile: Option[java.io.File] = None) extends PeekPokeTester(dut, base, logFile) with VerilogTbDump {

--- a/src/main/scala/dsptools/tester/VerilogTbDump.scala
+++ b/src/main/scala/dsptools/tester/VerilogTbDump.scala
@@ -15,7 +15,7 @@ import chisel3.iotesters.TestersCompatibility
 // Note: This will dump as long as genVerilogTb is true (even if you're peeking/poking DspReal)
 trait VerilogTbDump {
 
-  def dut: MultiIOModule
+  def dut: Module
 
   // Used for getting target directory only (set in iotesters.Driver)
   val iotestersOM = chisel3.iotesters.Driver.optionsManager

--- a/src/test/scala/dsptools/LoggingSpec.scala
+++ b/src/test/scala/dsptools/LoggingSpec.scala
@@ -22,7 +22,7 @@ class DutWithLoggingTester(c: DutWithLogging) extends DspTester(c)
 class LoggingSpec extends AnyFreeSpec with Matchers {
   "logging can be emitted during hardware generation" - {
     "level defaults to warn" in {
-      Logger.makeScope() {
+      Logger.makeScope(Seq.empty) {
         val captor = new Logger.OutputCaptor
         Logger.setOutput(captor.printStream)
 
@@ -37,7 +37,7 @@ class LoggingSpec extends AnyFreeSpec with Matchers {
       }
     }
     "logging level can be set via command line args" in {
-      Logger.makeScope() {
+      Logger.makeScope(Seq.empty) {
         val captor = new Logger.OutputCaptor
         Logger.setOutput(captor.printStream)
 
@@ -52,7 +52,7 @@ class LoggingSpec extends AnyFreeSpec with Matchers {
       }
     }
     "logging level can be set for a specific package" in {
-      Logger.makeScope() {
+      Logger.makeScope(Seq.empty) {
         val captor = new Logger.OutputCaptor
         Logger.setOutput(captor.printStream)
 

--- a/src/test/scala/dsptools/numbers/FixedPointSpec.scala
+++ b/src/test/scala/dsptools/numbers/FixedPointSpec.scala
@@ -158,7 +158,8 @@ class BrokenShifterTester(c: BrokenShifter) extends DspTester(c) {
 class FixedPointSpec extends AnyFreeSpec with Matchers {
   "FixedPoint numbers should work properly for the following mathematical type functions" - {
 //    for (backendName <- Seq("verilator")) {
-    for (backendName <- Seq("firrtl", "verilator")) {
+//    for (backendName <- Seq("treadle")) {
+    for (backendName <- Seq("treadle", "verilator")) {
       s"The ring family run with the $backendName simulator" - {
         for (binaryPoint <- 0 to 4 by 2) {
           s"should work, with binaryPoint $binaryPoint" in {
@@ -196,22 +197,6 @@ class FixedPointSpec extends AnyFreeSpec with Matchers {
           }
         }
       }
-
-      //TODO: This error does not seem to be caught at this time.  Firrtl issue #450
-      s"shifting by too big a number causes error with $backendName" ignore {
-        for(shiftSize <- 8 to 10) {
-          dsptools.Driver.execute(
-            () => new BrokenShifter(n = shiftSize),
-            Array(
-              "--backend-name", backendName,
-              "--target-dir", s"test_run_dir/broken-shifter-$shiftSize"
-            )
-          ) { c =>
-            new BrokenShifterTester(c)
-          } should be(true)
-        }
-      }
-
     }
   }
 }

--- a/src/test/scala/dsptools/numbers/IntervalSpec.scala
+++ b/src/test/scala/dsptools/numbers/IntervalSpec.scala
@@ -162,9 +162,9 @@ class IntervalBrokenShifterTester(c: IntervalBrokenShifter) extends DspTester(c)
 class IntervalSpec extends AnyFreeSpec with Matchers {
   "Interval numbers should work properly for the following mathematical type functions" - {
 //    for (backendName <- Seq("verilator")) {
-//    for (backendName <- Seq("treadle")) {
+    for (backendName <- Seq("treadle")) {
 //    for (backendName <- Seq("firrtl")) {
-    for (backendName <- Seq("treadle", "verilator")) {
+//    for (backendName <- Seq("treadle", "verilator")) {
       s"The ring family run with the $backendName simulator" - {
         for (binaryPoint <- 0 to 4 by 2) {
           s"should work, with binaryPoint $binaryPoint" in {
@@ -200,21 +200,6 @@ class IntervalSpec extends AnyFreeSpec with Matchers {
               new IntervalShifterTest(c)
             } should be(true)
           }
-        }
-      }
-
-      //TODO: This error does not seem to be caught at this time.  Firrtl issue #450
-      s"shifting by too big a number causes error with $backendName" ignore {
-        for(shiftSize <- 8 to 10) {
-          dsptools.Driver.execute(
-            () => new IntervalBrokenShifter(n = shiftSize),
-            Array(
-              "--backend-name", backendName,
-              "--target-dir", s"test_run_dir/broken-shifter-$shiftSize"
-            )
-          ) { c =>
-            new IntervalBrokenShifterTester(c)
-          } should be(true)
         }
       }
     }

--- a/src/test/scala/dsptools/numbers/SaturateSpec.scala
+++ b/src/test/scala/dsptools/numbers/SaturateSpec.scala
@@ -9,7 +9,7 @@ import dsptools.numbers.rounding.Saturate
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class SaturateUIntMod(val add: Boolean) extends MultiIOModule {
+class SaturateUIntMod(val add: Boolean) extends Module {
   val a = IO(Input(UInt(8.W)))
   val b = IO(Input(UInt(8.W)))
   val c = IO(Output(UInt()))
@@ -53,7 +53,7 @@ class SaturateUIntTester(dut: SaturateUIntMod) extends PeekPokeTester(dut) {
   }
 }
 
-class SaturateSIntMod(val add: Boolean) extends MultiIOModule {
+class SaturateSIntMod(val add: Boolean) extends Module {
   val a = IO(Input(SInt(8.W)))
   val b = IO(Input(SInt(8.W)))
   val c = IO(Output(SInt()))
@@ -96,7 +96,7 @@ class SaturateSIntTester(dut: SaturateSIntMod) extends PeekPokeTester(dut) {
   }
 }
 
-class SaturateFixedPointMod(val add: Boolean, val aBP: Int = 0, val bBP: Int = 0) extends MultiIOModule {
+class SaturateFixedPointMod(val add: Boolean, val aBP: Int = 0, val bBP: Int = 0) extends Module {
   val cBP = aBP max bBP
   val a = IO(Input(FixedPoint(8.W, aBP.BP)))
   val b = IO(Input(FixedPoint(8.W, bBP.BP)))

--- a/src/test/scala/examples/ComplexDivideExample.scala
+++ b/src/test/scala/examples/ComplexDivideExample.scala
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+My first issue is :
+How do I divide by 2 a DspComplex[T] ?
+
+My input is two ADC with 8 bit each. The output is 8 bit DAC.
+The output should be the sum of the inputs - amplitude does not matter as long as the hardware is utilized.
+
+Is there a context in dsptools I can use, that will make summing two 8 bit numbers -> result in the sum not saturating?
+For example in case of getting 255 in both inputs the result should be 510/2 = 255
+Even better if I could use signed addition to do the same...
+I thought about dividing the input by 2 and then summing - is this the way?
+ */
+
+package examples
+
+import chisel3._
+import dsptools._
+import dsptools.numbers._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class ComplexDivider extends Module {
+  val in = IO(Input(DspComplex(SInt(8.W), SInt(8.W))))
+  val out = IO(Output(DspComplex(SInt(), SInt())))
+
+  out.real := (in.real +& in.imag)
+  out.imag := (in.real +& in.imag) / 2.S
+}
+
+class ComplexDivideBy2 extends AnyFreeSpec with Matchers {
+  "divide by 2" in {
+    dsptools.Driver.execute(
+      () => new ComplexDivider,
+      Array.empty[String]
+    ) { c => new DspTester(c) {
+        poke(c.in.real, 127.S)
+        poke(c.in.imag, 127.S)
+        println(s"got " + peek(c.out.real))
+        println(s"got " + peek(c.out.imag))
+        step(1)
+        poke(c.in.real, -128.S)
+        poke(c.in.imag, -128.S)
+        println(s"got " + peek(c.out.real))
+        println(s"got " + peek(c.out.imag))
+      }
+    } should be (true)
+  }
+}

--- a/src/test/scala/examples/PassThroughExamples.scala
+++ b/src/test/scala/examples/PassThroughExamples.scala
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package examples
+
+import chisel3._
+import chisel3.stage.ChiselStage
+import chisel3.util._
+import chisel3.experimental.FixedPoint
+import dsptools._
+import dsptools.numbers._
+import breeze.math.Complex
+import org.scalatest.freespec.AnyFreeSpec
+import spire.algebra.Ring
+import spire.implicits._
+
+object PassThrough{
+  def apply[T<:Data:Real](  gen: T                        ):PassThrough[T] = {
+    new PassThrough(        gen,                1         )
+  }
+  def apply[T<:Data:Real](  gen: T,             lanes:Int ):PassThrough[T] = {
+    new PassThrough(        gen,                lanes     )
+  }
+  def apply[T<:Data:Real](  gen: DspComplex[T]            ):PassThroughComplex[T] = {
+    new PassThroughComplex( gen,                1         )
+  }
+  def apply[T<:Data:Real](  gen: DspComplex[T], lanes:Int ):PassThroughComplex[T] = {
+    new PassThroughComplex( gen,                lanes     )
+  }
+}
+class  PassThroughComplex[T<:Data:Real](gen: DspComplex[T], lanes:Int = 1 )
+  extends Module {
+  val io = IO(new Bundle {
+    val in  = Input(  Vec( lanes, gen ) )
+    val out = Output( Vec( lanes, gen ) )
+  })
+  io.out := io.in
+}
+class  PassThrough[T<:Data:Real](gen: T, lanes:Int = 1 )
+  extends Module {
+  val io = IO(new Bundle {
+    val in  = Input(  Vec( lanes, gen ) )
+    val out = Output( Vec( lanes, gen ) )
+  })
+  io.out := io.in
+}
+
+
+class MuxVec[T<:Data:Real]( tt:T, lanes:Int = 1 )
+  extends Module{
+  val io = IO(new Bundle {
+    val in   = Input( Vec(           lanes, tt ) )
+    val addr = Input( UInt( log2Ceil(lanes).W  ) )
+    val out  = Output(                      tt   )
+  })
+  io.out := io.in(io.addr)
+}
+
+class MuxVecComplex[T<:Data:Real]( tt:DspComplex[T], lanes:Int = 1 )
+  extends Module{
+  val io = IO(new Bundle {
+    val in   = Input( Vec(           lanes, tt ) )
+    val addr = Input( UInt( log2Ceil(lanes).W  ) )
+    val out  = Output(                      tt   )
+  })
+  io.out := io.in(io.addr)
+}
+
+class PassThroughExamples extends AnyFreeSpec {
+  "First set of examples" in {
+    println(ChiselStage.emitVerilog(PassThrough(UInt(6.W))))
+    println(ChiselStage.emitVerilog(PassThrough(UInt(4.W), 2)))
+
+    println(ChiselStage.emitVerilog(PassThrough(SInt(6.W))))
+    println(ChiselStage.emitVerilog(PassThrough(SInt(4.W), 3)))
+
+    println(ChiselStage.emitVerilog(PassThrough(FixedPoint(6.W, 4.BP))))
+    println(ChiselStage.emitVerilog(PassThrough(FixedPoint(6.W, 4.BP), 3)))
+
+    println(ChiselStage.emitVerilog(PassThrough(DspComplex(SInt(8.W), SInt(4.W)))))
+    println(ChiselStage.emitVerilog(PassThrough(DspComplex(SInt(8.W), SInt(4.W)), 3)))
+
+    println(ChiselStage.emitVerilog(PassThrough(DspComplex(FixedPoint(8.W, 4.BP), FixedPoint(4.W, 2.BP)))))
+    println(ChiselStage.emitVerilog(PassThrough(DspComplex(FixedPoint(8.W, 4.BP), FixedPoint(4.W, 2.BP)), 3)))
+
+    // DspComplex with only real part
+    println(ChiselStage.emitVerilog(PassThrough(DspComplex(FixedPoint(8.W, 4.BP), FixedPoint(0.W, 0.BP)))))
+  }
+
+  "second set of examples" in {
+    println( ChiselStage.emitVerilog( new MuxVec(       UInt(4.W)          ) )  )
+    println( ChiselStage.emitVerilog( new MuxVec(       UInt(4.W)      , 3 ) )  )
+    println( ChiselStage.emitVerilog( new MuxVec( FixedPoint(6.W, 4.BP), 3 ) )  )
+  }
+
+  "third examples" in {
+    println( ChiselStage.emitVerilog( new MuxVecComplex( DspComplex( SInt(8.W),             SInt(4.W)             )    )  ))
+    println( ChiselStage.emitVerilog( new MuxVecComplex( DspComplex( SInt(8.W),             SInt(4.W)             ), 3 )  ))
+
+    println( ChiselStage.emitVerilog( new MuxVecComplex( DspComplex( FixedPoint(8.W, 4.BP), FixedPoint(4.W, 2.BP) )    )  ))
+    println( ChiselStage.emitVerilog( new MuxVecComplex( DspComplex( FixedPoint(8.W, 4.BP), FixedPoint(4.W, 2.BP) ), 3 )  ))
+  }
+}


### PR DESCRIPTION
Fixes to move dsptools to cleaner 3.5
- Fixed most calls to Logger.makeScope, Converted to empty annotation seq
- Remove deprecated CircuitForm usages
- Removed tests that showed firrtl error (firrtl has been fixed)
- Fixed deprecated form of LitValue
- Removed parens on .isLit
- Change all references to MultiIOModule to Module



