### PR TITLE
Fix multiple issues for 3.5.0-RC2 Release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ enablePlugins(GhpagesPlugin)
 
 val defaultVersions = Map(
   "chisel-iotesters" -> "2.5-SNAPSHOT",
+  "chisel3" -> "3.5-SNAPSHOT",
 )
 
 name := "dsptools"
@@ -67,6 +68,7 @@ val commonSettings = Seq(
   libraryDependencies ++= Seq("chisel-iotesters").map { dep: String =>
     "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
   },
+  addCompilerPlugin("edu.berkeley.cs" %% "chisel3-plugin" % defaultVersions("chisel3") cross CrossVersion.full),
 )
 
 val dsptoolsSettings = Seq(

--- a/src/main/scala/dsptools/Driver.scala
+++ b/src/main/scala/dsptools/Driver.scala
@@ -68,7 +68,7 @@ object Driver {
       blackBoxFactories = optionsManager.treadleOptions.blackBoxFactories :+ new TreadleDspRealFactory
     )
 
-    logger.Logger.makeScope(optionsManager) {
+    logger.LoggerCompatibility.makeScope(optionsManager) {
       val chiselResult: ChiselExecutionResult = iotesters.DriverCompatibility.execute(optionsManager, dutGenerator)
       chiselResult match {
         case iotesters.DriverCompatibility.ChiselExecutionSuccess(_, emitted, _) =>

--- a/src/main/scala/dsptools/numbers/algebra_types/helpers/Sign.scala
+++ b/src/main/scala/dsptools/numbers/algebra_types/helpers/Sign.scala
@@ -38,8 +38,6 @@ sealed class Sign(zeroInit: Option[Boolean] = None, negInit: Option[Boolean] = N
   // LSB indicates even or oddness -- only negative if this is negative and 
   // it's raised by an odd power
   def **(that: UInt): Sign = Sign(this.zero, this.neg && that(0))
-
-  override def cloneType = new Sign(zeroInit, negInit).asInstanceOf[this.type]
 }
 
 object Sign {

--- a/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
+++ b/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
@@ -75,10 +75,6 @@ class DspComplex[T <: Data:Ring](val real: T, val imag: T) extends Bundle {
   // Uses implicits
   def abssq(dummy: Int = 0): T = (real * real) + (imag * imag)
 
-  override def cloneType: this.type = {
-    new DspComplex(real.cloneType, imag.cloneType).asInstanceOf[this.type]
-  }
-
   def underlyingType(dummy: Int = 0): String = {
     real match {
       case _: Interval   => "interval"

--- a/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
+++ b/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
@@ -19,11 +19,11 @@ object DspComplex {
   // In reality, real and imag should have the same type, so should be using single argument
   // apply if you aren't trying t create a Lit
   def apply[T <: Data:Ring](real: T, imag: T): DspComplex[T] = {
-    if(real.isLit() && imag.isLit()) {
-      new DspComplex(real, imag).Lit(_.real -> real, _.imag -> imag)
+    val newReal = if (real.isLit) real.cloneType else real
+    val newImag = if (imag.isLit) imag.cloneType else imag
+    if(real.isLit && imag.isLit) {
+      new DspComplex(newReal, newImag).Lit(_.real -> real, _.imag -> imag)
     } else {
-      val newReal = if (real.isLit()) real else real.cloneType
-      val newImag = if (imag.isLit()) imag else imag.cloneType
       new DspComplex(newReal, newImag)
     }
   }

--- a/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
+++ b/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
@@ -12,7 +12,7 @@ object DspComplex {
 
   def apply[T <: Data:Ring](gen: T): DspComplex[T] = {
     if (gen.isLit()) throw DspException("Cannot use Lit in single argument DspComplex.apply")
-    apply(gen, gen)
+    apply(gen.cloneType, gen.cloneType)
   }
 
   // If real, imag are literals, the literals are carried through

--- a/src/main/scala/dsptools/numbers/chisel_concrete/DspReal.scala
+++ b/src/main/scala/dsptools/numbers/chisel_concrete/DspReal.scala
@@ -4,14 +4,12 @@ package dsptools.numbers
 
 import chisel3._
 import chisel3.util.Mux1H
+import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor
 
 //scalastyle:off number.of.methods
-class DspReal(val lit: Option[BigInt] = None) extends Bundle {
-  
-  val node: UInt = lit match {
-    case Some(x) => x.U(DspReal.underlyingWidth.W)
-    case _ => Output(UInt(DspReal.underlyingWidth.W))
-  }
+class DspReal() extends Bundle {
+
+  val node: UInt = Output(UInt(DspReal.underlyingWidth.W))
 
   private def oneOperandOperator(blackbox_gen: => BlackboxOneOperand) : DspReal = {
     val blackbox = blackbox_gen
@@ -346,19 +344,17 @@ class DspReal(val lit: Option[BigInt] = None) extends Bundle {
 
 object DspReal {
   val underlyingWidth = 64
-  private val zero = DspReal(0.0, false)
+
+  @deprecated("addZero doesn't do anything", "dsptools 1.5")
+  def apply(value: Double, addZero: Boolean): DspReal = apply(value)
 
   /** Creates a Real with a constant value.
     */
-  def apply(value: Double, addZero: Boolean = true): DspReal = {
+  def apply(value: Double): DspReal = {
     // See http://stackoverflow.com/questions/21212993/unsigned-variables-in-scala
     def longAsUnsignedBigInt(in: Long): BigInt = (BigInt(in >>> 1) << 1) + (in & 1)
     def doubleToBigInt(in: Double): BigInt = longAsUnsignedBigInt(java.lang.Double.doubleToRawLongBits(in))
-    if (addZero) {
-      new DspReal(Some(doubleToBigInt(value))) + zero
-    } else {
-      new DspReal(Some(doubleToBigInt(value)))
-    }
+    (new DspReal()).Lit(_.node -> doubleToBigInt(value).U)
   }
 
   /**

--- a/src/test/scala/dsptools/VerboseDspTesterSpec/SimpleTBwGenTypeOption.scala
+++ b/src/test/scala/dsptools/VerboseDspTesterSpec/SimpleTBwGenTypeOption.scala
@@ -84,7 +84,6 @@ class DataTypeBundle[R <: Data:Real](genType: R, dataWidth: Width, binaryPoint: 
   val s = SInt(dataWidth)
   val f = FixedPoint(dataWidth, binaryPoint)
   val u = UInt(dataWidth)
-  override def cloneType: this.type = new DataTypeBundle(genType, dataWidth, binaryPoint).asInstanceOf[this.type]
 }
 
 class Interface[R <: Data:Real](genShort: R, genLong: R, includeR: Boolean, p: TestParams) extends Bundle {
@@ -109,8 +108,6 @@ class Interface[R <: Data:Real](genShort: R, genLong: R, includeR: Boolean, p: T
   val vU = Vec(vecLen, UInt(smallW))
   val vS = Vec(vecLen, SInt(smallW))
   val vF = Vec(vecLen, FixedPoint(smallW, smallBP))
-
-  override def cloneType: this.type = new Interface(genShort, genLong, includeR, p).asInstanceOf[this.type]
 }
 
 class SimpleIOModule[R <: Data:Real](genShort: R, genLong: R, val includeR: Boolean, val p: TestParams)

--- a/src/test/scala/examples/CaseClassBundleSpec.scala
+++ b/src/test/scala/examples/CaseClassBundleSpec.scala
@@ -16,7 +16,6 @@ import org.scalatest.matchers.should.Matchers
 //}
 class CaseClassBundle(gen: SInt) extends Bundle {
     val underlying = gen
-    override def cloneType: this.type = new CaseClassBundle(underlying.cloneType).asInstanceOf[this.type]
 }
 
 class SimpleCaseClassModule(gen: SInt) extends Module {

--- a/src/test/scala/examples/SimpleDspModuleSpec.scala
+++ b/src/test/scala/examples/SimpleDspModuleSpec.scala
@@ -25,7 +25,6 @@ class SimpleDspIo[T <: Data:RealBits](gen: T) extends Bundle {
   val x = Input(gen.cloneType)
   val y = Input(gen.cloneType)
   val z = Output(gen.cloneType)
-  override def cloneType: this.type = new SimpleDspIo(gen).asInstanceOf[this.type]
 }
 
 // Parameterized Chisel Module; takes in type parameters as explained above


### PR DESCRIPTION
This ballooned into several fixes in order to get CI passing:
* Use iotesters polyfill for removed Logger method
* Use chisel3 compiler plugin and delete cloneType implementations
* Fix DspComplex handling of lits
* Fix DspReal handling of lits 

In the case of `DspReal`, this is unfortunately a source incompatible change. It's not clear if it's possible to do this in a way that would be backwards compatible. The previous code was including a literal in the elements of the `DspReal` `Bundle` and this is something that was never really intended in Chisel3. It violates many internal assumptions and often would result in errors. The checking for this case now happens earlier and thus the code had to change.

Needed for 3.5.0-RC2