### PR TITLE
Update master for 1.5.0 release

### DIFF
--- a/.github/configs/mergify_config.yml
+++ b/.github/configs/mergify_config.yml
@@ -1,0 +1,7 @@
+# Configuration for generating .mergify.yml
+conditions:
+  - status-success=all tests passed
+branches:
+  - 1.3.x
+  - 1.4.x
+  - 1.5.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - 1.5.x
       - 1.4.x
       - 1.3.x
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,107 +1,110 @@
+queue_rules:
+- name: default
+  conditions:
+  - status-success=all tests passed
 pull_request_rules:
-  - name: automatic squash-and-merge on CI success and review
-    conditions:
-      - status-success=all tests passed
-      - '#approved-reviews-by>=1'
-      - '#changes-requested-reviews-by=0'
-      - base=master
-      - label="Please Merge"
-      - label!="DO NOT MERGE"
-      - label!="bp-conflict"
-    actions:
-      merge:
-        method: squash
-        strict: smart
-        strict_method: merge
-  - name: backport to 1.4.x
-    conditions:
-      - merged
-      - base=master
-      - milestone=1.4.x
-    actions:
-      backport:
-        branches:
-          - 1.4.x
-        ignore_conflicts: true
-        label_conflicts: bp-conflict
-      label:
-        add:
-          - Backported
-  - name: backport to 1.3.x, 1.4.x
-    conditions:
-      - merged
-      - base=master
-      - milestone=1.3.x
-    actions:
-      backport:
-        branches:
-          - 1.3.x
-          - 1.4.x
-        ignore_conflicts: true
-        label_conflicts: bp-conflict
-      label:
-        add:
-          - Backported
-  - name: backport to 1.2.x, 1.3.x, 1.4.x
-    conditions:
-      - merged
-      - base=master
-      - milestone=1.2.x
-    actions:
-      backport:
-        branches:
-          - 1.2.x
-          - 1.3.x
-          - 1.4.x
-        ignore_conflicts: true
-        label_conflicts: bp-conflict
-      label:
-        add:
-          - Backported
-  - name: label Mergify backport PR
-    conditions:
-      - body~=This is an automated backport of pull request \#\d+ done by Mergify
-    actions:
-      label:
-        add:
-          - Backport
-  - name: automatic squash-and-mege of 1.2.x backport PRs
-    conditions:
-      - status-success=all tests passed
-      - '#changes-requested-reviews-by=0'
-      - base=1.2.x
-      - label="Backport"
-      - label!="DO NOT MERGE"
-      - label!="bp-conflict"
-    actions:
-      merge:
-        method: squash
-        strict: smart
-        strict_method: merge
-  - name: automatic squash-and-mege of 1.3.x backport PRs
-    conditions:
-      - status-success=all tests passed
-      - '#changes-requested-reviews-by=0'
-      - base=1.3.x
-      - label="Backport"
-      - label!="DO NOT MERGE"
-      - label!="bp-conflict"
-    actions:
-      merge:
-        method: squash
-        strict: smart
-        strict_method: merge
-  - name: automatic squash-and-mege of 1.4.x backport PRs
-    conditions:
-      - status-success=all tests passed
-      - '#changes-requested-reviews-by=0'
-      - base=1.4.x
-      - label="Backport"
-      - label!="DO NOT MERGE"
-      - label!="bp-conflict"
-    actions:
-      merge:
-        method: squash
-        strict: smart
-        strict_method: merge
+- name: automatic squash-and-merge on CI success and review
+  conditions:
+  - status-success=all tests passed
+  - '#approved-reviews-by>=1'
+  - '#changes-requested-reviews-by=0'
+  - base=master
+  - label="Please Merge"
+  - label!="DO NOT MERGE"
+  - label!="bp-conflict"
+  actions:
+    queue:
+      name: default
+      method: squash
+      update_method: merge
+- name: backport to 1.5.x
+  conditions:
+  - merged
+  - base=master
+  - milestone=1.5.x
+  actions:
+    backport:
+      branches:
+      - 1.5.x
+      labels:
+      - Backport
+      ignore_conflicts: true
+      label_conflicts: bp-conflict
+    label:
+      add:
+      - Backported
+- name: backport to 1.4.x, 1.5.x
+  conditions:
+  - merged
+  - base=master
+  - milestone=1.4.x
+  actions:
+    backport:
+      branches:
+      - 1.4.x
+      - 1.5.x
+      labels:
+      - Backport
+      ignore_conflicts: true
+      label_conflicts: bp-conflict
+    label:
+      add:
+      - Backported
+- name: backport to 1.3.x, 1.4.x, 1.5.x
+  conditions:
+  - merged
+  - base=master
+  - milestone=1.3.x
+  actions:
+    backport:
+      branches:
+      - 1.3.x
+      - 1.4.x
+      - 1.5.x
+      labels:
+      - Backport
+      ignore_conflicts: true
+      label_conflicts: bp-conflict
+    label:
+      add:
+      - Backported
+- name: automatic squash-and-mege of 1.3.x backport PRs
+  conditions:
+  - status-success=all tests passed
+  - '#changes-requested-reviews-by=0'
+  - base=1.3.x
+  - label="Backport"
+  - label!="DO NOT MERGE"
+  - label!="bp-conflict"
+  actions:
+    queue:
+      name: default
+      method: squash
+      update_method: merge
+- name: automatic squash-and-mege of 1.4.x backport PRs
+  conditions:
+  - status-success=all tests passed
+  - '#changes-requested-reviews-by=0'
+  - base=1.4.x
+  - label="Backport"
+  - label!="DO NOT MERGE"
+  - label!="bp-conflict"
+  actions:
+    queue:
+      name: default
+      method: squash
+      update_method: merge
+- name: automatic squash-and-mege of 1.5.x backport PRs
+  conditions:
+  - status-success=all tests passed
+  - '#changes-requested-reviews-by=0'
+  - base=1.5.x
+  - label="Backport"
+  - label!="DO NOT MERGE"
+  - label!="bp-conflict"
+  actions:
+    queue:
+      name: default
+      method: squash
+      update_method: merge
 


### PR DESCRIPTION
* Enable CI for 1.5.x branch
* Enable Mergify for 1.5.x branch
* Drop 1.2.x from Mergify

This also updates the mergify configuration to be valid, see https://github.com/chipsalliance/chisel3/pull/2334