### PR TITLE
Remove chiseltest hack for peeking and poking FixedPoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -344,3 +344,6 @@ hs_err_pid*
 
 # ignore lib from rocket build
 lib
+
+# bsp
+.bsp/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "fixedpoint"]
 	path = fixedpoint
-	url = https://github.com/ucb-bar/fixedpoint
+	url = https://github.com/ucb-bar/fixedpoint.git

--- a/build.sbt
+++ b/build.sbt
@@ -5,17 +5,13 @@ enablePlugins(SiteScaladocPlugin)
 enablePlugins(GhpagesPlugin)
 
 val defaultVersions = Map(
-  "chisel3" -> "3.6-SNAPSHOT",
-  "chiseltest" -> "0.6-SNAPSHOT"
+  "chisel3" -> "3.6.0",
+  "chiseltest" -> "0.6.2"
 )
 
 name := "dsptools"
 
 val commonSettings = Seq(
-  organization := "edu.berkeley.cs",
-  version := "1.6-SNAPSHOT",
-  git.remoteRepo := "git@github.com:ucb-bar/dsptools.git",
-  autoAPIMappings := true,
   scalaVersion := "2.13.10",
   scalacOptions ++= Seq("-encoding",
                         "UTF-8",
@@ -25,32 +21,59 @@ val commonSettings = Seq(
                         "-language:reflectiveCalls",
                         "-Xfatal-warnings",
                         "-Ymacro-annotations"),
-  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
-  pomExtra := (<url>http://chisel.eecs.berkeley.edu/</url>
-  <licenses>
-    <license>
-      <name>apache_v2</name>
-      <url>https://opensource.org/licenses/Apache-2.0</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-  <developers>
-    <developer>
-      <id>grebe</id>
-      <name>Paul Rigge</name>
-      <url>http://www.eecs.berkeley.edu/~rigge/</url>
-    </developer>
-    <developer>
-      <id>shunshou</id>
-      <name>Angie Wang</name>
-      <url>https://www.linkedin.com/in/angie-wang-ee/</url>
-    </developer>
-    <developer>
-      <id>chick</id>
-      <name>Charles Markley</name>
-      <url>https://aspire.eecs.berkeley.edu/author/chick/</url>
-    </developer>
-   </developers>),
+  resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
+  resolvers ++= Resolver.sonatypeOssRepos("releases"),
+  libraryDependencies ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, major)) if major <= 12 => Seq()
+      case _                               => Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4")
+    }
+  },
+  libraryDependencies ++= Seq("chisel3").map { dep: String =>
+    "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
+  },
+  addCompilerPlugin(("edu.berkeley.cs" %% "chisel3-plugin" % defaultVersions("chisel3")).cross(CrossVersion.full)),
+)
+
+val dsptoolsSettings = Seq(
+  name := "dsptools",
+  organization := "edu.berkeley.cs",
+  version := "1.6-SNAPSHOT",
+  git.remoteRepo := "git@github.com:ucb-bar/dsptools.git",
+  autoAPIMappings := true,
+  libraryDependencies ++= Seq(
+    "org.typelevel" %% "spire" % "0.18.0",
+    "org.scalanlp" %% "breeze" % "2.1.0",
+    "org.scalatest" %% "scalatest" % "3.2.15" % "test"
+  ),
+  libraryDependencies ++= Seq("chiseltest").map { dep: String =>
+    "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
+  },
+  pomExtra := <url>http://chisel.eecs.berkeley.edu/</url>
+    <licenses>
+      <license>
+        <name>apache_v2</name>
+        <url>https://opensource.org/licenses/Apache-2.0</url>
+        <distribution>repo</distribution>
+      </license>
+    </licenses>
+    <developers>
+      <developer>
+        <id>grebe</id>
+        <name>Paul Rigge</name>
+        <url>http://www.eecs.berkeley.edu/~rigge/</url>
+      </developer>
+      <developer>
+        <id>shunshou</id>
+        <name>Angie Wang</name>
+        <url>https://www.linkedin.com/in/angie-wang-ee/</url>
+      </developer>
+      <developer>
+        <id>chick</id>
+        <name>Charles Markley</name>
+        <url>https://aspire.eecs.berkeley.edu/author/chick/</url>
+      </developer>
+    </developers>,
   publishTo := {
     val v = version.value
     val nexus = "https://oss.sonatype.org/"
@@ -60,29 +83,6 @@ val commonSettings = Seq(
       Some("releases".at(nexus + "service/local/staging/deploy/maven2"))
     }
   },
-  resolvers ++= Seq(
-    Resolver.sonatypeRepo("snapshots"),
-    Resolver.sonatypeRepo("releases")
-  ),
-  libraryDependencies ++= {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, major)) if major <= 12 => Seq()
-      case _                               => Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.3")
-    }
-  },
-  libraryDependencies ++= Seq("chisel3", "chiseltest").map { dep: String =>
-    "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
-  },
-  addCompilerPlugin(("edu.berkeley.cs" %% "chisel3-plugin" % defaultVersions("chisel3")).cross(CrossVersion.full)),
-)
-
-val dsptoolsSettings = Seq(
-  name := "dsptools",
-  libraryDependencies ++= Seq(
-    "org.typelevel" %% "spire" % "0.18.0",
-    "org.scalanlp" %% "breeze" % "2.1.0",
-    "org.scalatest" %% "scalatest" % "3.2.15" % "test"
-  ),
 )
 
 val fixedpointSettings = Seq(
@@ -94,7 +94,7 @@ val fixedpointSettings = Seq(
 
 publishMavenStyle := true
 
-publishArtifact in Test := false
+Test / publishArtifact := false
 pomIncludeRepository := { x =>
   false
 }
@@ -117,5 +117,5 @@ val dsptools = (project in file("."))
   .dependsOn(fixedpoint)
   //.enablePlugins(BuildInfoPlugin)
   .enablePlugins(ScalaUnidocPlugin)
-  .settings(commonSettings: _*)
-  .settings(dsptoolsSettings: _*)
+  .settings(commonSettings)
+  .settings(dsptoolsSettings)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.8.2

--- a/src/main/scala/dsptools/misc/PeekPokeDspExtensions.scala
+++ b/src/main/scala/dsptools/misc/PeekPokeDspExtensions.scala
@@ -13,15 +13,12 @@ import dsptools.numbers._
 trait PeekPokeDspExtensions {
   this: PeekPokeTester[_] =>
 
-  private def fixedName(node: FixedPoint): String =
-    node.instanceName.replace('.', '_')
-
   private def dspPeek(node: Data): (Double, BigInt) = {
     val bi: BigInt = node match {
       // Unsigned bigint
       case r: DspReal    => peek(r.node.asInstanceOf[Bits])
       case b: Bits       => peek(b.asInstanceOf[Bits])
-      case f: FixedPoint => peek(fixedName(f))
+      case f: FixedPoint => peek(f.asSInt.asInstanceOf[Bits])
     }
     val (dblOut, bigIntOut) = node match {
       case _: DspReal => (DspTesterUtilities.bigIntBitsToDouble(bi), bi)
@@ -62,7 +59,7 @@ trait PeekPokeDspExtensions {
       case f: FixedPoint =>
         f.binaryPoint match {
           case KnownBinaryPoint(bp) =>
-            poke(fixedName(f) /*f.asSInt.asInstanceOf[Bits]*/, FixedPoint.toBigInt(value, bp))
+            poke(f.asSInt.asInstanceOf[Bits], FixedPoint.toBigInt(value, bp))
           case _ => throw DspException("Must poke FixedPoint with known binary point")
         }
       case r: DspReal => poke(r.node.asInstanceOf[Bits], DspTesterUtilities.doubleToBigIntBits(value))

--- a/src/test/scala/dsptools/numbers/LnSpec.scala
+++ b/src/test/scala/dsptools/numbers/LnSpec.scala
@@ -21,11 +21,12 @@ class LnTester(c: LnModule) extends PeekPokeTester(c) with PeekPokeDspExtensions
   poke(c.io.num, 11.0)
   private val x = peek(c.io.ln)
   println(s"poked 1.0 got $x expected ${math.log(11.0)}")
-
 }
+
 class LnSpec extends AnyFreeSpec with ChiselScalatestTester {
   "ln should work" in {
     test(new LnModule)
+      .withAnnotations(Seq(VerilatorBackendAnnotation))
       .runPeekPoke(new LnTester(_))
   }
 }


### PR DESCRIPTION
Main change pertains to `PeekPokeDspExtensions`, where a temporary workaround for peeking and poking `FixedPoint` has been removed due to chiseltest now properly supporting `OpaqueType` as of 0.6.2.

Also, sbt version has been bumped to 1.8.2 and build.sbt has been cleaned up appropriately. There's also some minor cleanup in the repository.