### PR TITLE
Update Chisel version to 5.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ enablePlugins(SiteScaladocPlugin)
 enablePlugins(GhpagesPlugin)
 
 val defaultVersions = Map(
-  "chisel3" -> "3.6.0",
-  "chiseltest" -> "0.6.2"
+  "chisel" -> "5.1.0",
+  "chiseltest" -> "5.0.2"
 )
 
 name := "dsptools"
@@ -29,10 +29,10 @@ val commonSettings = Seq(
       case _                               => Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4")
     }
   },
-  libraryDependencies ++= Seq("chisel3").map { dep: String =>
-    "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
+  libraryDependencies ++= Seq("chisel").map { dep: String =>
+    "org.chipsalliance" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
   },
-  addCompilerPlugin(("edu.berkeley.cs" %% "chisel3-plugin" % defaultVersions("chisel3")).cross(CrossVersion.full)),
+  addCompilerPlugin(("org.chipsalliance" %% "chisel-plugin" % defaultVersions("chisel")).cross(CrossVersion.full)),
 )
 
 val dsptoolsSettings = Seq(

--- a/doc/Example.md
+++ b/doc/Example.md
@@ -6,7 +6,7 @@ A basic DSP Module + Tester might look like this:
 package SimpleDsp
 
 // Allows you to use Chisel Module, Bundle, etc.
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 // Allows you to use FixedPoint
 import fixedpoint._
 // If you want to take advantage of type classes >> Data:RealBits (i.e. pass in FixedPoint or DspReal)

--- a/rocket/src/main/scala/jtag2mm/TestMultiplexer.scala
+++ b/rocket/src/main/scala/jtag2mm/TestMultiplexer.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.jtag2mm
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import chisel3.util._
 import chisel3.experimental.{FixedPoint => _, _}
 import fixedpoint._

--- a/src/main/scala/dsptools/misc/DspTesterUtilities.scala
+++ b/src/main/scala/dsptools/misc/DspTesterUtilities.scala
@@ -2,7 +2,7 @@
 
 package dsptools.misc
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
 import dsptools.DspException
 import dsptools.numbers.{DspComplex, DspReal}

--- a/src/main/scala/dsptools/misc/PeekPokeDspExtensions.scala
+++ b/src/main/scala/dsptools/misc/PeekPokeDspExtensions.scala
@@ -3,7 +3,7 @@
 package dsptools.misc
 
 import breeze.math.Complex
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
 import chiseltest.iotesters.PeekPokeTester
 import dsptools.DspException

--- a/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
+++ b/src/main/scala/dsptools/numbers/chisel_concrete/DspComplex.scala
@@ -2,7 +2,7 @@
 
 package dsptools.numbers
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
 import dsptools.DspException
 import breeze.math.Complex

--- a/src/main/scala/dsptools/numbers/chisel_types/DspComplexTypeClass.scala
+++ b/src/main/scala/dsptools/numbers/chisel_types/DspComplexTypeClass.scala
@@ -2,7 +2,7 @@
 
 package dsptools.numbers
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
 import dsptools.hasContext
 import implicits._

--- a/src/main/scala/dsptools/numbers/chisel_types/DspRealTypeClass.scala
+++ b/src/main/scala/dsptools/numbers/chisel_types/DspRealTypeClass.scala
@@ -3,7 +3,7 @@
 package dsptools.numbers
 
 import chisel3.util.ShiftRegister
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import dsptools.{hasContext, DspContext, NoTrim}
 import fixedpoint._
 

--- a/src/main/scala/dsptools/numbers/chisel_types/FixedPointTypeClass.scala
+++ b/src/main/scala/dsptools/numbers/chisel_types/FixedPointTypeClass.scala
@@ -2,7 +2,7 @@
 
 package dsptools.numbers
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
 import chisel3.util.ShiftRegister
 import dsptools._

--- a/src/main/scala/dsptools/numbers/chisel_types/SIntTypeClass.scala
+++ b/src/main/scala/dsptools/numbers/chisel_types/SIntTypeClass.scala
@@ -2,7 +2,7 @@
 
 package dsptools.numbers
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import chisel3.util.{Cat, ShiftRegister}
 import dsptools.{hasContext, DspContext, DspException, Grow, NoTrim, Saturate, Wrap}
 import fixedpoint._

--- a/src/main/scala/dsptools/numbers/chisel_types/UIntTypeClass.scala
+++ b/src/main/scala/dsptools/numbers/chisel_types/UIntTypeClass.scala
@@ -2,7 +2,7 @@
 
 package dsptools.numbers
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import chisel3.util.{Cat, ShiftRegister}
 import dsptools.{hasContext, DspContext, DspException, Grow, Saturate, Wrap}
 import fixedpoint._

--- a/src/main/scala/dsptools/numbers/implicits/AllOps.scala
+++ b/src/main/scala/dsptools/numbers/implicits/AllOps.scala
@@ -2,7 +2,7 @@
 
 package dsptools.numbers
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import spire.macros.Ops
 
 import scala.language.experimental.macros

--- a/src/test/scala/dsptools/ShiftRegisterDelaySpec.scala
+++ b/src/test/scala/dsptools/ShiftRegisterDelaySpec.scala
@@ -2,7 +2,7 @@
 
 package dsptools
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import chiseltest._
 import chiseltest.iotesters._
 import dsptools.misc.PeekPokeDspExtensions

--- a/src/test/scala/dsptools/numbers/AbsSpec.scala
+++ b/src/test/scala/dsptools/numbers/AbsSpec.scala
@@ -2,9 +2,8 @@
 
 package dsptools.numbers
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
-import chisel3.experimental.{FixedPoint => _, _}
 import dsptools.{DspContext, Grow, Wrap}
 import org.scalatest.freespec.AnyFreeSpec
 import chiseltest._

--- a/src/test/scala/dsptools/numbers/FixedPointSpec.scala
+++ b/src/test/scala/dsptools/numbers/FixedPointSpec.scala
@@ -5,7 +5,7 @@ package dsptools.numbers
 //scalastyle:off magic.number
 
 import chisel3.testers.BasicTester
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
 import dsptools.numbers.implicits._
 import org.scalatest.freespec.AnyFreeSpec

--- a/src/test/scala/dsptools/numbers/FixedPrecisionChangerSpec.scala
+++ b/src/test/scala/dsptools/numbers/FixedPrecisionChangerSpec.scala
@@ -2,7 +2,7 @@
 
 package dsptools.numbers
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
 import chiseltest._
 import chiseltest.iotesters._

--- a/src/test/scala/dsptools/numbers/NumbersSpec.scala
+++ b/src/test/scala/dsptools/numbers/NumbersSpec.scala
@@ -2,7 +2,7 @@
 
 package dsptools.numbers
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
 import chiseltest._
 import chiseltest.experimental.sanitizeFileName

--- a/src/test/scala/dsptools/numbers/ParameterizedOpSpec.scala
+++ b/src/test/scala/dsptools/numbers/ParameterizedOpSpec.scala
@@ -3,7 +3,7 @@
 package dsptools.numbers
 
 import breeze.math.Complex
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
 import chiseltest._
 import chiseltest.iotesters._

--- a/src/test/scala/dsptools/numbers/TypeclassSpec.scala
+++ b/src/test/scala/dsptools/numbers/TypeclassSpec.scala
@@ -2,7 +2,7 @@
 
 package dsptools.numbers
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
 import chiseltest._
 import chiseltest.iotesters._

--- a/src/test/scala/examples/ParameterizedAdderSpec.scala
+++ b/src/test/scala/examples/ParameterizedAdderSpec.scala
@@ -2,7 +2,7 @@
 
 package examples
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
 import chiseltest._
 import chiseltest.iotesters.PeekPokeTester

--- a/src/test/scala/examples/SimpleAdderSpec.scala
+++ b/src/test/scala/examples/SimpleAdderSpec.scala
@@ -2,7 +2,7 @@
 
 package examples
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
 import chiseltest._
 import chiseltest.iotesters.PeekPokeTester

--- a/src/test/scala/examples/SimpleComplexMultiplierSpec.scala
+++ b/src/test/scala/examples/SimpleComplexMultiplierSpec.scala
@@ -2,7 +2,7 @@
 
 package examples
 
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import fixedpoint._
 import chiseltest._
 import chiseltest.iotesters._

--- a/src/test/scala/examples/SimpleDspModuleSpec.scala
+++ b/src/test/scala/examples/SimpleDspModuleSpec.scala
@@ -3,7 +3,7 @@
 package examples
 
 // Allows you to use Chisel Module, Bundle, etc.
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import dsptools.misc.PeekPokeDspExtensions
 // Allows you to use FixedPoint
 import fixedpoint._


### PR DESCRIPTION
Bumps `fixedpoint` to include https://github.com/ucb-bar/fixedpoint/pull/8.

Note that this is not compatible with Chisel 3.6.0.